### PR TITLE
Custom parachain id in chain name 

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -62,12 +62,6 @@ pub struct ExportGenesisStateCommand {
     #[structopt(parse(from_os_str))]
     pub output: Option<PathBuf>,
 
-    /// Id of the parachain this state is for.
-    ///
-    /// Default: 2004
-    #[structopt(long)]
-    pub parachain_id: Option<u32>,
-
     /// Write output in binary. Default is to write in hex.
     #[structopt(short, long)]
     pub raw: bool,

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -33,14 +33,19 @@ use std::{io::Write, net::SocketAddr};
 
 use crate::service::Block;
 
-fn load_spec(
-    id: &str,
-) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
     let (norm_id, para_id) = extract_parachain_id(id);
-    info!("Loading spec: {}, custom parachain-id = {:?})", norm_id, para_id);
+    info!(
+        "Loading spec: {}, custom parachain-id = {:?})",
+        norm_id, para_id
+    );
     Ok(match norm_id {
-        "khala-dev" => Box::new(chain_spec::khala_development_config(para_id.expect("Must specify parachain id"))),
-        "khala-local" => Box::new(chain_spec::khala_local_config(para_id.expect("Must specify parachain id"))),
+        "khala-dev" => Box::new(chain_spec::khala_development_config(
+            para_id.expect("Must specify parachain id"),
+        )),
+        "khala-local" => Box::new(chain_spec::khala_local_config(
+            para_id.expect("Must specify parachain id"),
+        )),
         "khala-staging" => Box::new(chain_spec::khala_staging_config()),
         "khala" => Box::new(chain_spec::ChainSpec::from_json_bytes(
             &include_bytes!("../res/khala.json")[..],
@@ -235,9 +240,8 @@ pub fn run() -> Result<()> {
             builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
             let _ = builder.init();
 
-            let block: Block = generate_genesis_block(&load_spec(
-                &params.chain.clone().unwrap_or_default()
-            )?)?;
+            let block: Block =
+                generate_genesis_block(&load_spec(&params.chain.clone().unwrap_or_default())?)?;
             let raw_header = block.header().encode();
             let output_buf = if params.raw {
                 raw_header
@@ -300,8 +304,12 @@ pub fn run() -> Result<()> {
                         .chain(cli.relaychain_args.iter()),
                 );
 
-                let id = ParaId::from(cli.run.parachain_id.or(para_id)
-                    .expect("Unable to determine parachain id"));
+                let id = ParaId::from(
+                    cli.run
+                        .parachain_id
+                        .or(para_id)
+                        .expect("Unable to determine parachain id"),
+                );
 
                 let parachain_account =
                     AccountIdConversion::<polkadot_primitives::v0::AccountId>::into_account(&id);

--- a/scripts/export-parachain-genesis.sh
+++ b/scripts/export-parachain-genesis.sh
@@ -5,5 +5,5 @@ mkdir -p tmp/kernels
 ./target/release/khala-node export-genesis-wasm -r --chain khala-staging > ./tmp/kernels/staging-genesis.wasm
 ./target/release/khala-node export-genesis-state --chain khala-staging > ./tmp/kernels/staging-state.hex
 
-./target/release/khala-node export-genesis-wasm -r --chain khala-local > ./tmp/kernels/local-genesis.wasm
-./target/release/khala-node export-genesis-state --chain khala-local > ./tmp/kernels/local-state.hex
+./target/release/khala-node export-genesis-wasm -r --chain khala-local-2004 > ./tmp/kernels/local-genesis.wasm
+./target/release/khala-node export-genesis-state --chain khala-local-2004 > ./tmp/kernels/local-state.hex


### PR DESCRIPTION
Allow customize parachain id by adding a prefix to the chain name.
It only applies to "khala-dev" and "khala-local".

E.g.:"khala-local-2004" means "khala-local" at para 2004