### PR TITLE
Port paritytech/cumulus/pull/538

### DIFF
--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -192,7 +192,7 @@ construct_runtime! {
 
         // Parachain staff
         ParachainInfo: pallet_parachain_info::{Pallet, Storage, Config} = 20,
-        ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Config, Storage, Inherent, Event<T>} = 21,
+        ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Config, Storage, Inherent, Event<T>, ValidateUnsigned} = 21,
 
         // Monetary stuff
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 40,


### PR DESCRIPTION
I forgot port https://github.com/paritytech/cumulus/pull/538 when we upgrade to 0.9.8