### PR TITLE
Fix PHA resource id computation

### DIFF
--- a/pallets/xtransfer/src/assets_wrapper.rs
+++ b/pallets/xtransfer/src/assets_wrapper.rs
@@ -12,7 +12,7 @@ pub mod pallet {
 	use xcm::latest::{prelude::*, MultiLocation};
 
 	#[derive(Clone, Decode, Encode, Eq, PartialEq, Ord, PartialOrd, Debug, TypeInfo)]
-	pub struct XTransferAsset(MultiLocation);
+	pub struct XTransferAsset(pub MultiLocation);
 
 	// Const used to indicate chainbridge assets. str "cb"
 	pub const CB_ASSET_KEY: &[u8] = &[0x63, 0x62];

--- a/pallets/xtransfer/src/bridge/mock.rs
+++ b/pallets/xtransfer/src/bridge/mock.rs
@@ -135,9 +135,6 @@ pub fn new_test_ext_initialized(
 		assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_C));
 		// Whitelist chain
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), src_id));
-		// Set and check resource ID mapped to some junk data
-		assert_ok!(Bridge::set_resource(Origin::root(), r_id, resource));
-		assert_eq!(Bridge::resource_exists(r_id), true);
 	});
 	t
 }

--- a/pallets/xtransfer/src/bridge/mock.rs
+++ b/pallets/xtransfer/src/bridge/mock.rs
@@ -121,8 +121,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 pub fn new_test_ext_initialized(
 	src_id: BridgeChainId,
-	r_id: ResourceId,
-	resource: Vec<u8>,
+	_r_id: ResourceId,
+	_resource: Vec<u8>,
 ) -> sp_io::TestExternalities {
 	let mut t = new_test_ext();
 	t.execute_with(|| {

--- a/pallets/xtransfer/src/bridge/tests.rs
+++ b/pallets/xtransfer/src/bridge/tests.rs
@@ -75,24 +75,6 @@ fn complete_proposal_bad_threshold() {
 }
 
 #[test]
-fn setup_resources() {
-	new_test_ext().execute_with(|| {
-		let id: ResourceId = [1; 32];
-		let method = "Pallet.do_something".as_bytes().to_vec();
-		let method2 = "Pallet.do_somethingElse".as_bytes().to_vec();
-
-		assert_ok!(Bridge::set_resource(Origin::root(), id, method.clone()));
-		assert_eq!(Bridge::resources(id), Some(method));
-
-		assert_ok!(Bridge::set_resource(Origin::root(), id, method2.clone()));
-		assert_eq!(Bridge::resources(id), Some(method2));
-
-		assert_ok!(Bridge::remove_resource(Origin::root(), id));
-		assert_eq!(Bridge::resources(id), None);
-	})
-}
-
-#[test]
 fn whitelist_chain() {
 	new_test_ext().execute_with(|| {
 		assert!(!Bridge::chain_whitelisted(0));

--- a/pallets/xtransfer/src/bridge_transfer/mock.rs
+++ b/pallets/xtransfer/src/bridge_transfer/mock.rs
@@ -104,11 +104,6 @@ impl bridge::Config for Test {
 	type ProposalLifetime = ProposalLifetime;
 }
 
-parameter_types! {
-	// First byte is 0x00, chain id of ethereum mainnet
-	pub const NativeTokenResourceId: [u8; 32] = hex!("0096dcf98ada5bc4d4b647e4d9636b8ea78487421e1f156af8b47830aab82844");
-}
-
 impl bridge_transfer::Config for Test {
 	type Event = Event;
 	type AssetsWrapper = AssetsWrapper;
@@ -116,7 +111,6 @@ impl bridge_transfer::Config for Test {
 	type BridgeOrigin = bridge::EnsureBridge<Test>;
 	type Currency = Balances;
 	type XcmTransactor = ();
-	type NativeTokenResourceId = NativeTokenResourceId;
 	type OnFeePay = ();
 }
 

--- a/pallets/xtransfer/src/bridge_transfer/mock.rs
+++ b/pallets/xtransfer/src/bridge_transfer/mock.rs
@@ -2,7 +2,6 @@
 
 use frame_support::{ord_parameter_types, parameter_types, weights::Weight, PalletId};
 use frame_system::{self as system};
-use hex_literal::hex;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,

--- a/pallets/xtransfer/src/bridge_transfer/mod.rs
+++ b/pallets/xtransfer/src/bridge_transfer/mod.rs
@@ -70,10 +70,6 @@ pub mod pallet {
 		/// XCM transactor
 		type XcmTransactor: XcmTransact<Self>;
 
-		/// PHA resource id
-		#[pallet::constant]
-		type NativeTokenResourceId: Get<ResourceId>;
-
 		/// The handler to absorb the fee.
 		type OnFeePay: OnUnbalanced<NegativeImbalanceOf<Self>>;
 	}
@@ -271,7 +267,7 @@ pub mod pallet {
 
 			<bridge::Pallet<T>>::transfer_fungible(
 				dest_id,
-				T::NativeTokenResourceId::get(),
+				Self::get_pha_rid(dest_id),
 				recipient,
 				U256::from(amount.saturated_into::<u128>()),
 			)
@@ -291,12 +287,13 @@ pub mod pallet {
 		) -> DispatchResult {
 			let bridge_account = T::BridgeOrigin::ensure_origin(origin.clone())?;
 			// For solo chain assets, we encode solo chain id as the first byte of resourceId
-			let src_id: u128 = rid[0]
-				.try_into()
-				.expect("Convert from chain id to u128 must be ok; qed.");
+			let src_chainid: bridge::BridgeChainId = rid[0];
 			let src_reserve_location: MultiLocation = (
 				0,
-				X2(GeneralKey(CB_ASSET_KEY.to_vec()), GeneralIndex(src_id)),
+				X2(
+					GeneralKey(CB_ASSET_KEY.to_vec()),
+					GeneralIndex(src_chainid as u128),
+				),
 			)
 				.into();
 
@@ -327,7 +324,7 @@ pub mod pallet {
 			// Note: If we received asset send from its reserve chain, we just need
 			// mint the same amount of asset at local
 			if asset_reserve_location != src_reserve_location {
-				if rid == T::NativeTokenResourceId::get() {
+				if rid == Self::get_pha_rid(src_chainid) {
 					// ERC20 PHA save reserved assets in bridge account
 					let _imbalance = <T as Config>::Currency::withdraw(
 						&bridge_account,
@@ -358,7 +355,7 @@ pub mod pallet {
 			match (dest_location.parents, &dest_location.interior) {
 				// To local account
 				(0, &X1(AccountId32 { network: _, id })) => {
-					if rid == T::NativeTokenResourceId::get() {
+					if rid == Self::get_pha_rid(src_chainid) {
 						// ERC20 PHA transfer
 						<T as Config>::Currency::deposit_creating(&id.into(), amount);
 					} else {
@@ -383,7 +380,7 @@ pub mod pallet {
 							target: LOG_TARGET,
 							"Reserve of asset and dest dismatch, deposit asset to dest reserve location.",
 						);
-						if rid == T::NativeTokenResourceId::get() {
+						if rid == Self::get_pha_rid(src_chainid) {
 							<T as Config>::Currency::deposit_creating(
 								&dest_reserve_account.clone().into(),
 								amount,
@@ -449,7 +446,8 @@ pub mod pallet {
 		}
 
 		pub fn rid_to_location(rid: &[u8; 32]) -> Result<MultiLocation, DispatchError> {
-			let asset_location: MultiLocation = if *rid == T::NativeTokenResourceId::get() {
+			let src_chainid: bridge::BridgeChainId = rid[0];
+			let asset_location: MultiLocation = if *rid == Self::get_pha_rid(src_chainid) {
 				MultiLocation::here()
 			} else {
 				let xtransfer_asset: XTransferAsset = T::AssetsWrapper::lookup_by_resource_id(&rid)
@@ -462,8 +460,9 @@ pub mod pallet {
 		pub fn rid_to_assetid(
 			rid: &[u8; 32],
 		) -> Result<<T as pallet_assets::Config>::AssetId, DispatchError> {
+			let src_chainid: bridge::BridgeChainId = rid[0];
 			// PHA based on pallet_balances, not pallet_assets
-			if *rid == T::NativeTokenResourceId::get() {
+			if *rid == Self::get_pha_rid(src_chainid) {
 				return Err(Error::<T>::AssetNotRegistered.into());
 			}
 			let xtransfer_asset: XTransferAsset = T::AssetsWrapper::lookup_by_resource_id(&rid)
@@ -471,6 +470,10 @@ pub mod pallet {
 			let asset_id: <T as pallet_assets::Config>::AssetId =
 				T::AssetsWrapper::id(&xtransfer_asset).ok_or(Error::<T>::AssetNotRegistered)?;
 			Ok(asset_id)
+		}
+
+		pub fn get_pha_rid(chain_id: bridge::BridgeChainId) -> bridge::ResourceId {
+			XTransferAsset(MultiLocation::here()).into_rid(chain_id)
 		}
 	}
 }

--- a/pallets/xtransfer/src/bridge_transfer/tests.rs
+++ b/pallets/xtransfer/src/bridge_transfer/tests.rs
@@ -587,7 +587,6 @@ fn create_successful_transfer_proposal() {
 		let prop_id = 1;
 		let src_id = 1;
 		let r_id = BridgeTransfer::gen_pha_rid(src_id);
-		let resource = b"BridgeTransfer.transfer".to_vec();
 		let relayer_location = MultiLocation::new(
 			0,
 			X1(AccountId32 {

--- a/pallets/xtransfer/src/bridge_transfer/tests.rs
+++ b/pallets/xtransfer/src/bridge_transfer/tests.rs
@@ -15,7 +15,7 @@ use xcm::latest::prelude::*;
 const TEST_THRESHOLD: u32 = 2;
 
 fn make_transfer_proposal(dest: Vec<u8>, src_id: u8, amount: u64) -> Call {
-	let resource_id = BridgeTransfer::get_pha_rid(src_id);
+	let resource_id = BridgeTransfer::gen_pha_rid(src_id);
 	Call::BridgeTransfer(crate::bridge_transfer::Call::transfer {
 		dest,
 		amount: amount.into(),
@@ -324,7 +324,7 @@ fn transfer_assets_to_reserve() {
 fn transfer_native() {
 	new_test_ext().execute_with(|| {
 		let dest_chain = 0;
-		let resource_id = BridgeTransfer::get_pha_rid(dest_chain);
+		let resource_id = BridgeTransfer::gen_pha_rid(dest_chain);
 		let amount: u64 = 100;
 		let recipient = vec![99];
 
@@ -369,7 +369,7 @@ fn simulate_transfer_pha_from_solochain() {
 		// Check inital state
 		let bridge_account = Bridge::account_id();
 		let src_chainid = 0;
-		let resource_id = BridgeTransfer::get_pha_rid(src_chainid);
+		let resource_id = BridgeTransfer::gen_pha_rid(src_chainid);
 		assert_eq!(Balances::free_balance(&bridge_account), ENDOWED_BALANCE);
 		let relayer_location = MultiLocation::new(
 			0,
@@ -586,7 +586,7 @@ fn create_successful_transfer_proposal() {
 	new_test_ext().execute_with(|| {
 		let prop_id = 1;
 		let src_id = 1;
-		let r_id = BridgeTransfer::get_pha_rid(src_id);
+		let r_id = BridgeTransfer::gen_pha_rid(src_id);
 		let resource = b"BridgeTransfer.transfer".to_vec();
 		let relayer_location = MultiLocation::new(
 			0,

--- a/pallets/xtransfer/src/bridge_transfer/tests.rs
+++ b/pallets/xtransfer/src/bridge_transfer/tests.rs
@@ -4,8 +4,8 @@ use crate::assets_wrapper::pallet::{AccountId32Conversion, GetAssetRegistryInfo,
 use crate::bridge;
 use crate::bridge_transfer::mock::{
 	assert_events, balances, expect_event, new_test_ext, Assets, AssetsWrapper, Balances, Bridge,
-	BridgeTransfer, Call, Event, NativeTokenResourceId, Origin, ProposalLifetime, Test, ALICE,
-	ENDOWED_BALANCE, RELAYER_A, RELAYER_B, RELAYER_C,
+	BridgeTransfer, Call, Event, Origin, ProposalLifetime, Test, ALICE, ENDOWED_BALANCE, RELAYER_A,
+	RELAYER_B, RELAYER_C,
 };
 use codec::Encode;
 use frame_support::{assert_noop, assert_ok};
@@ -14,8 +14,8 @@ use xcm::latest::prelude::*;
 
 const TEST_THRESHOLD: u32 = 2;
 
-fn make_transfer_proposal(dest: Vec<u8>, amount: u64) -> Call {
-	let resource_id = NativeTokenResourceId::get();
+fn make_transfer_proposal(dest: Vec<u8>, src_id: u8, amount: u64) -> Call {
+	let resource_id = BridgeTransfer::get_pha_rid(src_id);
 	Call::BridgeTransfer(crate::bridge_transfer::Call::transfer {
 		dest,
 		amount: amount.into(),
@@ -324,7 +324,7 @@ fn transfer_assets_to_reserve() {
 fn transfer_native() {
 	new_test_ext().execute_with(|| {
 		let dest_chain = 0;
-		let resource_id = NativeTokenResourceId::get();
+		let resource_id = BridgeTransfer::get_pha_rid(dest_chain);
 		let amount: u64 = 100;
 		let recipient = vec![99];
 
@@ -368,7 +368,8 @@ fn simulate_transfer_pha_from_solochain() {
 	new_test_ext().execute_with(|| {
 		// Check inital state
 		let bridge_account = Bridge::account_id();
-		let resource_id = NativeTokenResourceId::get();
+		let src_chainid = 0;
+		let resource_id = BridgeTransfer::get_pha_rid(src_chainid);
 		assert_eq!(Balances::free_balance(&bridge_account), ENDOWED_BALANCE);
 		let relayer_location = MultiLocation::new(
 			0,
@@ -585,7 +586,7 @@ fn create_successful_transfer_proposal() {
 	new_test_ext().execute_with(|| {
 		let prop_id = 1;
 		let src_id = 1;
-		let r_id = NativeTokenResourceId::get();
+		let r_id = BridgeTransfer::get_pha_rid(src_id);
 		let resource = b"BridgeTransfer.transfer".to_vec();
 		let relayer_location = MultiLocation::new(
 			0,
@@ -594,14 +595,13 @@ fn create_successful_transfer_proposal() {
 				id: RELAYER_A.into(),
 			}),
 		);
-		let proposal = make_transfer_proposal(relayer_location.encode(), 10);
+		let proposal = make_transfer_proposal(relayer_location.encode(), src_id, 10);
 
 		assert_ok!(Bridge::set_threshold(Origin::root(), TEST_THRESHOLD,));
 		assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_A));
 		assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_B));
 		assert_ok!(Bridge::add_relayer(Origin::root(), RELAYER_C));
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), src_id));
-		assert_ok!(Bridge::set_resource(Origin::root(), r_id, resource));
 
 		// Create proposal (& vote)
 		assert_ok!(Bridge::acknowledge_proposal(

--- a/pallets/xtransfer/src/xcm/xcm_helper.rs
+++ b/pallets/xtransfer/src/xcm/xcm_helper.rs
@@ -247,11 +247,22 @@ pub mod xcm_helper {
 						}
 					}
 
+					// Currently, we use chainbridge forwards transfer to solo chain, which use resource id
+					// to indicate an asset.
+					//
+					// When asset is native token, e.g. PHA, we need transfer the location to MultiLocation::here()
+					// from (1, X1(Parachain(id))) to match resource id registered in solo chains.
+					let rid = if NativeChecker::is_native_asset(what) {
+						XTransferAsset(MultiLocation::here()).into_rid(dest_id)
+					} else {
+						xtransfer_asset.into_rid(dest_id)
+					};
+
 					// This operation will not do real transfer, it just emits FungibleTransfer event
 					// to notify relayers submit proposal to our bridge contract that deployed on EVM chains.
 					BridgeTransactor::transfer_fungible(
 						dest_id,
-						xtransfer_asset.into_rid(dest_id),
+						rid,
 						recipient.to_vec(),
 						U256::from(amount),
 					)

--- a/pallets/xtransfer/src/xcm/xcm_transfer.rs
+++ b/pallets/xtransfer/src/xcm/xcm_transfer.rs
@@ -106,7 +106,7 @@ pub mod pallet {
 		#[pallet::weight(195_000_000 + Pallet::<T>::estimate_transfer_weight())]
 		pub fn transfer_asset(
 			origin: OriginFor<T>,
-			asset: pallet_assets_wrapper::XTransferAsset,
+			asset: Box<pallet_assets_wrapper::XTransferAsset>,
 			dest: MultiLocation,
 			amount: BalanceOf<T>,
 			dest_weight: Weight,
@@ -114,7 +114,7 @@ pub mod pallet {
 			let origin = T::ExecuteXcmOrigin::ensure_origin(origin)?;
 			// Get asset location by asset id
 			let asset_location: MultiLocation =
-				asset.try_into().map_err(|_| Error::<T>::AssetNotFound)?;
+				(*asset).try_into().map_err(|_| Error::<T>::AssetNotFound)?;
 			let multi_asset: MultiAsset = (asset_location, amount.into()).into();
 
 			Self::do_transfer_multiasset(origin, multi_asset, dest, dest_weight)

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1158,11 +1158,6 @@ impl pallet_bridge::Config for Runtime {
     type ProposalLifetime = ProposalLifetime;
 }
 
-parameter_types! {
-    // bridge::derive_resource_id(1, &bridge::hashing::blake2_128(b"PHA"));
-    pub const NativeTokenResourceId: [u8; 32] = hex_literal::hex!("00000000000000000000000000000063a7e2be78898ba83824b0c0cc8dfb6001");
-}
-
 impl pallet_bridge_transfer::Config for Runtime {
     type Event = Event;
     type AssetsWrapper = AssetsWrapper;
@@ -1170,7 +1165,6 @@ impl pallet_bridge_transfer::Config for Runtime {
     type BridgeOrigin = pallet_bridge::EnsureBridge<Runtime>;
     type Currency = Balances;
     type XcmTransactor = ();
-    type NativeTokenResourceId = NativeTokenResourceId;
     type OnFeePay = Treasury;
 }
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1166,11 +1166,6 @@ impl pallet_bridge::Config for Runtime {
     type ProposalLifetime = ProposalLifetime;
 }
 
-parameter_types! {
-    // bridge::derive_resource_id(1, &bridge::hashing::blake2_128(b"PHA"));
-    pub const NativeTokenResourceId: [u8; 32] = hex_literal::hex!("00000000000000000000000000000063a7e2be78898ba83824b0c0cc8dfb6001");
-}
-
 impl pallet_bridge_transfer::Config for Runtime {
     type Event = Event;
     type AssetsWrapper = AssetsWrapper;
@@ -1178,7 +1173,6 @@ impl pallet_bridge_transfer::Config for Runtime {
     type BridgeOrigin = pallet_bridge::EnsureBridge<Runtime>;
     type Currency = Balances;
     type XcmTransactor = ();
-    type NativeTokenResourceId = NativeTokenResourceId;
     type OnFeePay = Treasury;
 }
 

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1351,7 +1351,6 @@ impl pallet_bridge_transfer::Config for Runtime {
     type BridgeOrigin = pallet_bridge::EnsureBridge<Runtime>;
     type Currency = Balances;
     type XcmTransactor = XcmTransfer;
-    type NativeTokenResourceId = NativeTokenResourceId;
     type OnFeePay = Treasury;
 }
 

--- a/scripts/js/xtransfer.js
+++ b/scripts/js/xtransfer.js
@@ -271,14 +271,14 @@ function dumpResourceId(khalaApi, soloChainId) {
 
 async function main() {
     // create khala api
-    const khalaEndpoint = process.env.ENDPOINT || 'ws://35.215.162.102:9944';
+    const khalaEndpoint = process.env.ENDPOINT || 'ws://localhost:9944';
     const khalaProvider = new WsProvider(khalaEndpoint);
     const khalaApi = await ApiPromise.create({
         provider: khalaProvider,
     });
 
     // create karura api
-    const karuraEndpoint = process.env.ENDPOINT || 'ws://35.215.162.102:9955';
+    const karuraEndpoint = process.env.ENDPOINT || 'ws://localhost:9955';
     const karuraProvider = new WsProvider(karuraEndpoint);
     const karuraApi = await ApiPromise.create({
         provider: karuraProvider,

--- a/scripts/js/xtransfer.js
+++ b/scripts/js/xtransfer.js
@@ -201,7 +201,7 @@ async function transferAssetsKhalaAccounts(khalaApi, sender, recipient, amount) 
 // simulate EVM => Khala, call Bridge.Deposit()
 async function transferPhaFromEvmToKhala(khalaApi, bridge, sender, recipient, amount) {
     let khalaChainId = 1;
-    let phaResourceId = '0x0096dcf98ada5bc4d4b647e4d9636b8ea78487421e1f156af8b47830aab82844';
+    let phaResourceId = '0x00e6dfb61a2fb903df487c401663825643bb825d41695e63df8af6162ab145a6';
     // dest is not Account public key any more.
     let dest = khalaApi.createType('XcmV1MultiLocation', {
         // parents = 0 means we send to xcm local network(e.g. Khala network here)
@@ -221,13 +221,15 @@ async function transferPhaFromEvmToKhala(khalaApi, bridge, sender, recipient, am
         ethers.utils.hexZeroPad(ethers.utils.hexlify((dest.length - 2)/2), 32).substr(2) +
         dest.substr(2);
 
-    await bridge.deposit(khalaChainId, phaResourceId, data);
+    const tx = await bridge.deposit(khalaChainId, phaResourceId, data);
+    console.log(`Transfer PHA from EVM to Khala: ${tx.hash}`);
+
 }
 
 // simulate EVM => Khala => Karura, call Bridge.Deposit()
 async function transferPhaFromEvmToKarura(khalaApi, bridge, sender, recipient, amount) {
     let khalaChainId = 1;
-    let phaResourceId = '0x0096dcf98ada5bc4d4b647e4d9636b8ea78487421e1f156af8b47830aab82844';
+    let phaResourceId = '0x00e6dfb61a2fb903df487c401663825643bb825d41695e63df8af6162ab145a6';
     let dest = khalaApi.createType('XcmV1MultiLocation', {
         // parents = 1 means we wanna send to other parachains or relaychain
         parents: 1,
@@ -254,14 +256,10 @@ async function transferPhaFromEvmToKarura(khalaApi, bridge, sender, recipient, a
 }
 
 function dumpResourceId(khalaApi, soloChainId) {
-    // PHA resourceId: 0x0096dcf98ada5bc4d4b647e4d9636b8ea78487421e1f156af8b47830aab82844
+    // PHA resourceId: 0x00e6dfb61a2fb903df487c401663825643bb825d41695e63df8af6162ab145a6
     let pha = khalaApi.createType('XcmV1MultiLocation', {
-        parents: 1,
-        interior: khalaApi.createType('Junctions', {
-            X1: khalaApi.createType('XcmV1Junction', {
-                    Parachain: khalaApi.createType('Compact<U32>', khalaParaId)
-                })
-        })
+        parents: 0,
+        interior: khalaApi.createType('Junctions', "Here")
     }).toHex();
 
     let u8arid = blake2AsU8a(pha);
@@ -273,14 +271,14 @@ function dumpResourceId(khalaApi, soloChainId) {
 
 async function main() {
     // create khala api
-    const khalaEndpoint = process.env.ENDPOINT || 'ws://localhost:9944';
+    const khalaEndpoint = process.env.ENDPOINT || 'ws://35.215.162.102:9944';
     const khalaProvider = new WsProvider(khalaEndpoint);
     const khalaApi = await ApiPromise.create({
         provider: khalaProvider,
     });
 
     // create karura api
-    const karuraEndpoint = process.env.ENDPOINT || 'ws://localhost:9955';
+    const karuraEndpoint = process.env.ENDPOINT || 'ws://35.215.162.102:9955';
     const karuraProvider = new WsProvider(karuraEndpoint);
     const karuraApi = await ApiPromise.create({
         provider: karuraProvider,


### PR DESCRIPTION
- Remove resource id store in pallet-bridge

Previously we set a constant resource id for PHA, that because it just need match the rid configed in Ethereum,
now different solo chain have different resource id, even though they are both indicate PHA. So there is no need
store resource id in pallet-bridge any more, instead we compute it dynamically during transfer.

Dispatch `set_resource` and other resource setting relevant methods are removed too, including ChainBridge relayer side.

- Fix PHA resource id computation
 
Fix PHA resource id computation in `BridgeTransfer.transfer` and `XcmTransactor.deposit_asset` which would case PHA transfer with other solo chains except Ethereum(with chain id 0) failure.