### PR TITLE
xTransfer update

### DIFF
--- a/pallets/xtransfer/src/bridge_transfer/mock.rs
+++ b/pallets/xtransfer/src/bridge_transfer/mock.rs
@@ -20,7 +20,7 @@ pub use pallet_balances as balances;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 
-pub(crate) type Balance = u64;
+pub(crate) type Balance = u128;
 
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -63,7 +63,7 @@ impl frame_system::Config for Test {
 	type BlockHashCount = BlockHashCount;
 	type DbWeight = ();
 	type Version = ();
-	type AccountData = pallet_balances::AccountData<u64>;
+	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
@@ -75,7 +75,7 @@ impl frame_system::Config for Test {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u64 = 1;
+	pub const ExistentialDeposit: Balance = 1;
 }
 
 ord_parameter_types! {
@@ -118,6 +118,7 @@ impl bridge_transfer::Config for Test {
 	type NativeChecker = NativeAssetFilter<ParachainInfo>;
 	type NativeExecutionPrice = ();
 	type ExecutionPriceInfo = ();
+	type TreasuryAccount = ();
 }
 
 parameter_types! {
@@ -163,7 +164,7 @@ pub const ALICE: AccountId32 = AccountId32::new([0u8; 32]);
 pub const RELAYER_A: AccountId32 = AccountId32::new([1u8; 32]);
 pub const RELAYER_B: AccountId32 = AccountId32::new([2u8; 32]);
 pub const RELAYER_C: AccountId32 = AccountId32::new([3u8; 32]);
-pub const ENDOWED_BALANCE: u64 = 100_000_000;
+pub const ENDOWED_BALANCE: Balance = 100_000_000;
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let bridge_account = PalletId(*b"phala/bg").into_account();
@@ -171,7 +172,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		.build_storage::<Test>()
 		.unwrap();
 	let parachain_info_config = pallet_parachain_info::GenesisConfig {
-		parachain_id: 2004.into(),
+		parachain_id: 2004u32.into(),
 	};
 	<pallet_parachain_info::GenesisConfig as GenesisBuild<Test, _>>::assimilate_storage(
 		&parachain_info_config,

--- a/pallets/xtransfer/src/bridge_transfer/mod.rs
+++ b/pallets/xtransfer/src/bridge_transfer/mod.rs
@@ -480,4 +480,13 @@ pub mod pallet {
 			rid[0]
 		}
 	}
+
+	pub trait GetBridgeFee<T: Config> {
+		fn get_fee(chain_id: &bridge::BridgeChainId) -> (BalanceOf<T>, u32);
+	}
+	impl<T: Config> GetBridgeFee<T> for Pallet<T> {
+		fn get_fee(chain_id: &bridge::BridgeChainId) -> (BalanceOf<T>, u32) {
+			BridgeFee::<T>::get(&chain_id)
+		}
+	}
 }

--- a/pallets/xtransfer/src/bridge_transfer/mod.rs
+++ b/pallets/xtransfer/src/bridge_transfer/mod.rs
@@ -514,7 +514,7 @@ pub mod pallet {
 		BalanceOf<T>: From<u128> + Into<u128>,
 	{
 		fn get_fee(chain_id: bridge::BridgeChainId, asset: &MultiAsset) -> Option<u128> {
-			return match (&asset.id, &asset.fun) {
+			match (&asset.id, &asset.fun) {
 				(Concrete(asset_id), Fungible(amount)) => {
 					let fee_estimated_in_pha =
 						Self::estimate_fee_in_pha(chain_id, (*amount).into());
@@ -537,7 +537,7 @@ pub mod pallet {
 					}
 				}
 				_ => None,
-			};
+			}
 		}
 	}
 

--- a/pallets/xtransfer/src/bridge_transfer/tests.rs
+++ b/pallets/xtransfer/src/bridge_transfer/tests.rs
@@ -177,6 +177,8 @@ fn transfer_assets_insufficient_balance() {
 			Origin::root(),
 			0,
 			dest_chain,
+			true,
+			Box::new(Vec::new()),
 		));
 
 		// After registered, free balance of ALICE is 0
@@ -225,6 +227,8 @@ fn transfer_assets_to_nonreserve() {
 			Origin::root(),
 			0,
 			dest_chain,
+			true,
+			Box::new(Vec::new()),
 		));
 
 		// Mint some token to ALICE
@@ -283,6 +287,8 @@ fn transfer_assets_to_reserve() {
 			Origin::root(),
 			0,
 			dest_chain,
+			true,
+			Box::new(Vec::new()),
 		));
 
 		// Mint some token to ALICE
@@ -443,6 +449,8 @@ fn simulate_transfer_solochainassets_from_reserve_to_local() {
 			Origin::root(),
 			0,
 			src_chainid,
+			true,
+			Box::new(Vec::new()),
 		));
 
 		assert_eq!(Assets::balance(0, &ALICE), 0);
@@ -514,6 +522,8 @@ fn simulate_transfer_solochainassets_from_nonreserve_to_local() {
 			Origin::root(),
 			0,
 			src_chainid,
+			true,
+			Box::new(Vec::new()),
 		));
 
 		assert_eq!(Assets::balance(0, &ALICE), 0);

--- a/pallets/xtransfer/src/bridge_transfer/tests.rs
+++ b/pallets/xtransfer/src/bridge_transfer/tests.rs
@@ -3,9 +3,9 @@
 use crate::assets_wrapper::pallet::{AccountId32Conversion, GetAssetRegistryInfo, CB_ASSET_KEY};
 use crate::bridge;
 use crate::bridge_transfer::mock::{
-	assert_events, balances, expect_event, new_test_ext, Assets, AssetsWrapper, Balances, Bridge,
-	BridgeTransfer, Call, Event, Origin, ProposalLifetime, Test, ALICE, ENDOWED_BALANCE, RELAYER_A,
-	RELAYER_B, RELAYER_C,
+	assert_events, balances, expect_event, new_test_ext, Assets, AssetsWrapper, Balance, Balances,
+	Bridge, BridgeTransfer, Call, Event, Origin, ProposalLifetime, Test, ALICE, ENDOWED_BALANCE,
+	RELAYER_A, RELAYER_B, RELAYER_C,
 };
 use codec::Encode;
 use frame_support::{assert_noop, assert_ok};
@@ -14,7 +14,7 @@ use xcm::latest::prelude::*;
 
 const TEST_THRESHOLD: u32 = 2;
 
-fn make_transfer_proposal(dest: Vec<u8>, src_id: u8, amount: u64) -> Call {
+fn make_transfer_proposal(dest: Vec<u8>, src_id: u8, amount: Balance) -> Call {
 	let resource_id = BridgeTransfer::gen_pha_rid(src_id);
 	Call::BridgeTransfer(crate::bridge_transfer::Call::transfer {
 		dest,
@@ -125,7 +125,7 @@ fn transfer_assets_not_registered() {
 				GeneralKey(b"an asset".to_vec()),
 			),
 		);
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let recipient = vec![99];
 
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain));
@@ -157,7 +157,7 @@ fn transfer_assets_insufficient_balance() {
 				GeneralKey(b"an asset".to_vec()),
 			),
 		);
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let recipient = vec![99];
 
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain));
@@ -213,7 +213,7 @@ fn transfer_assets_to_nonreserve() {
 				GeneralKey(b"an asset".to_vec()),
 			),
 		);
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let recipient = vec![99];
 
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain));
@@ -277,7 +277,7 @@ fn transfer_assets_to_reserve() {
 				GeneralKey(b"an asset".to_vec()),
 			),
 		);
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let recipient = vec![99];
 
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain));
@@ -325,7 +325,7 @@ fn transfer_native() {
 	new_test_ext().execute_with(|| {
 		let dest_chain = 0;
 		let resource_id = BridgeTransfer::gen_pha_rid(dest_chain);
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let recipient = vec![99];
 
 		assert_ok!(Bridge::whitelist_chain(Origin::root(), dest_chain));
@@ -423,7 +423,7 @@ fn simulate_transfer_solochainassets_from_reserve_to_local() {
 		let bridge_asset: crate::pallet_assets_wrapper::XTransferAsset =
 			bridge_asset_location.clone().into();
 		let r_id: [u8; 32] = bridge_asset.clone().into_rid(src_chainid);
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let alice_location = MultiLocation::new(
 			0,
 			X1(AccountId32 {
@@ -495,7 +495,7 @@ fn simulate_transfer_solochainassets_from_nonreserve_to_local() {
 		);
 		let para_asset: crate::pallet_assets_wrapper::XTransferAsset =
 			para_asset_location.clone().into();
-		let amount: u64 = 100;
+		let amount: Balance = 100;
 		let alice_location = MultiLocation::new(
 			0,
 			X1(AccountId32 {

--- a/pallets/xtransfer/src/xcm/mock/para.rs
+++ b/pallets/xtransfer/src/xcm/mock/para.rs
@@ -282,6 +282,9 @@ impl Config for XcmConfig {
 		FungiblesTransactor,
 		xcm_helper::NativeAssetFilter<ParachainInfo>,
 		(),
+		(),
+		AccountId,
+		(),
 	>;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = NativeAsset;

--- a/pallets/xtransfer/src/xcm/mock/para.rs
+++ b/pallets/xtransfer/src/xcm/mock/para.rs
@@ -280,6 +280,8 @@ impl Config for XcmConfig {
 	type AssetTransactor = xcm_helper::XTransferAdapter<
 		CurrencyTransactor,
 		FungiblesTransactor,
+		XcmTransfer,
+		XcmTransfer,
 		xcm_helper::NativeAssetFilter<ParachainInfo>,
 		(),
 		(),

--- a/pallets/xtransfer/src/xcm/xcm_helper.rs
+++ b/pallets/xtransfer/src/xcm/xcm_helper.rs
@@ -336,9 +336,9 @@ pub mod xcm_helper {
 				// Try handle it with transfer adapter
 				_ => {
 					if NativeChecker::is_native_asset(what) {
-						NativeAdapter::deposit_asset(what, who).map_err(|e| return e)?;
+						NativeAdapter::deposit_asset(what, who)?;
 					} else {
-						AssetsAdapter::deposit_asset(what, who).map_err(|e| return e)?;
+						AssetsAdapter::deposit_asset(what, who)?;
 					}
 				}
 			}
@@ -359,9 +359,9 @@ pub mod xcm_helper {
 				&who,
 			);
 			let assets = if NativeChecker::is_native_asset(what) {
-				NativeAdapter::withdraw_asset(what, who).map_err(|e| return e)?
+				NativeAdapter::withdraw_asset(what, who)?
 			} else {
-				AssetsAdapter::withdraw_asset(what, who).map_err(|e| return e)?
+				AssetsAdapter::withdraw_asset(what, who)?
 			};
 			WithdrawHandler::on_withdrawn(what.clone(), who.clone())
 				.map_err(|e| return XcmError::FailedToTransactAsset(e.into()))?;

--- a/pallets/xtransfer/src/xcm/xcm_helper.rs
+++ b/pallets/xtransfer/src/xcm/xcm_helper.rs
@@ -258,11 +258,8 @@ pub mod xcm_helper {
 							.map_err(|_| XcmError::FailedToTransactAsset("FeeTransferFailed"))?;
 					}
 
+					// transfering_amount > 0
 					let transfering_amount = amount - fee;
-					if transfering_amount == 0 {
-						// Transfering end
-						return Ok(());
-					}
 					let transfering_asset: MultiAsset =
 						(location.clone(), transfering_amount).into();
 					let dest_reserve: MultiLocation = (

--- a/pallets/xtransfer/src/xcm/xcm_helper.rs
+++ b/pallets/xtransfer/src/xcm/xcm_helper.rs
@@ -238,7 +238,7 @@ pub mod xcm_helper {
 					let fee = BridgeFeeInfo::get_fee(dest_id, what)
 						.ok_or(XcmError::FailedToTransactAsset("FailedGetFee"))?;
 					ensure!(
-						amount >= fee,
+						amount > fee,
 						XcmError::FailedToTransactAsset("Insufficient")
 					);
 					let fee_asset: MultiAsset = (location.clone(), fee).into();

--- a/pallets/xtransfer/src/xcm/xcm_transfer.rs
+++ b/pallets/xtransfer/src/xcm/xcm_transfer.rs
@@ -82,6 +82,16 @@ pub mod pallet {
 			origin: MultiLocation,
 			dest: MultiLocation,
 		},
+		/// Assets being deposited, including being deposited to reserve account of solo chains.
+		XcmDeposited {
+			what: MultiAsset,
+			who: MultiLocation,
+		},
+		/// Assets being withdrawn
+		XcmWithdrawn {
+			what: MultiAsset,
+			who: MultiLocation,
+		},
 	}
 
 	#[pallet::error]
@@ -259,6 +269,26 @@ pub mod pallet {
 			dest_weight: Weight,
 		) -> DispatchResult {
 			Self::do_transfer_multiasset(origin, asset, dest, dest_weight)
+		}
+	}
+
+	pub trait XcmOnDeposited {
+		fn on_deposited(what: MultiAsset, who: MultiLocation) -> DispatchResult;
+	}
+	impl<T: Config> XcmOnDeposited for Pallet<T> {
+		fn on_deposited(what: MultiAsset, who: MultiLocation) -> DispatchResult {
+			Self::deposit_event(Event::XcmDeposited { what, who });
+			Ok(())
+		}
+	}
+
+	pub trait XcmOnWithdrawn {
+		fn on_withdrawn(what: MultiAsset, who: MultiLocation) -> DispatchResult;
+	}
+	impl<T: Config> XcmOnWithdrawn for Pallet<T> {
+		fn on_withdrawn(what: MultiAsset, who: MultiLocation) -> DispatchResult {
+			Self::deposit_event(Event::XcmWithdrawn { what, who });
+			Ok(())
 		}
 	}
 

--- a/runtime/khala/src/constants.rs
+++ b/runtime/khala/src/constants.rs
@@ -34,7 +34,7 @@ pub mod currency {
 /// Fee-related.
 pub mod fee {
     use frame_support::weights::{
-        constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
+        constants::{ExtrinsicBaseWeight, WEIGHT_PER_SECOND}, WeightToFeeCoefficient, WeightToFeeCoefficients,
         WeightToFeePolynomial,
     };
     use parachains_common::Balance;
@@ -68,5 +68,13 @@ pub mod fee {
                 coeff_integer: p / q,
             }]
         }
+    }
+
+    pub fn pha_per_second() -> u128 {
+        // one cent cost per tx
+        let base_tx_fee = super::currency::CENTS;
+        let base_weight = Balance::from(ExtrinsicBaseWeight::get());
+        let tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;
+        base_tx_fee * tx_per_second
     }
 }

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -39,7 +39,7 @@ pub mod defaults;
 
 // Constant values used within the runtime.
 pub mod constants;
-use constants::{currency::*, fee::WeightToFee};
+use constants::{currency::*, fee::{pha_per_second, WeightToFee}};
 
 mod msg_routing;
 mod migrations;
@@ -98,7 +98,7 @@ pub use parachains_common::Index;
 pub use parachains_common::*;
 
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
-pub use xtransfer_pallets::{pallet_assets_wrapper, pallet_bridge, pallet_bridge_transfer};
+pub use xtransfer_pallets::{pallet_assets_wrapper, pallet_bridge, pallet_bridge_transfer, xcm_helper};
 
 #[cfg(any(feature = "std", test))]
 pub use frame_system::Call as SystemCall;
@@ -1148,6 +1148,7 @@ impl pallet_collator_selection::Config for Runtime {
 parameter_types! {
     pub const BridgeChainId: u8 = 1;
     pub const ProposalLifetime: BlockNumber = 50400; // ~7 days
+    pub NativeExecutionPrice: u128 = pha_per_second();
 }
 
 impl pallet_bridge::Config for Runtime {
@@ -1166,6 +1167,9 @@ impl pallet_bridge_transfer::Config for Runtime {
     type Currency = Balances;
     type XcmTransactor = ();
     type OnFeePay = Treasury;
+    type NativeChecker = xcm_helper::NativeAssetFilter<ParachainInfo>;
+    type NativeExecutionPrice = NativeExecutionPrice;
+    type ExecutionPriceInfo = ();
 }
 
 pub struct MqCallMatcher;

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1170,6 +1170,7 @@ impl pallet_bridge_transfer::Config for Runtime {
     type NativeChecker = xcm_helper::NativeAssetFilter<ParachainInfo>;
     type NativeExecutionPrice = NativeExecutionPrice;
     type ExecutionPriceInfo = ();
+    type TreasuryAccount = ();
 }
 
 pub struct MqCallMatcher;

--- a/runtime/rhala/src/constants.rs
+++ b/runtime/rhala/src/constants.rs
@@ -34,7 +34,7 @@ pub mod currency {
 /// Fee-related.
 pub mod fee {
     use frame_support::weights::{
-        constants::ExtrinsicBaseWeight, WeightToFeeCoefficient, WeightToFeeCoefficients,
+        constants::{ExtrinsicBaseWeight, WEIGHT_PER_SECOND}, WeightToFeeCoefficient, WeightToFeeCoefficients,
         WeightToFeePolynomial,
     };
     use parachains_common::Balance;
@@ -68,5 +68,13 @@ pub mod fee {
                 coeff_integer: p / q,
             }]
         }
+    }
+
+    pub fn pha_per_second() -> u128 {
+        // one cent cost per tx
+        let base_tx_fee = super::currency::CENTS;
+        let base_weight = Balance::from(ExtrinsicBaseWeight::get());
+        let tx_per_second = (WEIGHT_PER_SECOND as u128) / base_weight;
+        base_tx_fee * tx_per_second
     }
 }

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -39,7 +39,7 @@ pub mod defaults;
 
 // Constant values used within the runtime.
 pub mod constants;
-use constants::{currency::*, fee::WeightToFee};
+use constants::{currency::*, fee::{pha_per_second, WeightToFee}};
 
 mod msg_routing;
 mod migrations;
@@ -99,7 +99,7 @@ pub use parachains_common::*;
 
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
 
-pub use xtransfer_pallets::{pallet_assets_wrapper, pallet_bridge, pallet_bridge_transfer};
+pub use xtransfer_pallets::{pallet_assets_wrapper, pallet_bridge, pallet_bridge_transfer, xcm_helper};
 
 #[cfg(any(feature = "std", test))]
 pub use frame_system::Call as SystemCall;
@@ -1156,6 +1156,7 @@ impl pallet_collator_selection::Config for Runtime {
 parameter_types! {
     pub const BridgeChainId: u8 = 1;
     pub const ProposalLifetime: BlockNumber = 50400; // ~7 days
+    pub NativeExecutionPrice: u128 = pha_per_second();
 }
 
 impl pallet_bridge::Config for Runtime {
@@ -1174,6 +1175,9 @@ impl pallet_bridge_transfer::Config for Runtime {
     type Currency = Balances;
     type XcmTransactor = ();
     type OnFeePay = Treasury;
+    type NativeChecker = xcm_helper::NativeAssetFilter<ParachainInfo>;
+    type NativeExecutionPrice = NativeExecutionPrice;
+    type ExecutionPriceInfo = ();
 }
 
 pub struct MqCallMatcher;

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1178,6 +1178,7 @@ impl pallet_bridge_transfer::Config for Runtime {
     type NativeChecker = xcm_helper::NativeAssetFilter<ParachainInfo>;
     type NativeExecutionPrice = NativeExecutionPrice;
     type ExecutionPriceInfo = ();
+    type TreasuryAccount = ();
 }
 
 pub struct MqCallMatcher;

--- a/runtime/thala/src/constants.rs
+++ b/runtime/thala/src/constants.rs
@@ -89,5 +89,6 @@ pub mod parachains {
         pub const ID: u32 = 2001;
         pub const BNC_KEY: &[u8] = &[0, 1];
         pub const VSKSM_KEY: &[u8] = &[4, 4];
+        pub const ZLK_KEY: &[u8] = &[2, 7];
     }
 }

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1367,6 +1367,7 @@ impl pallet_bridge_transfer::Config for Runtime {
     type NativeChecker = xcm_helper::NativeAssetFilter<ParachainInfo>;
     type NativeExecutionPrice = NativeExecutionPrice;
     type ExecutionPriceInfo = ExecutionPrices;
+    type TreasuryAccount = KhalaTreasuryAccount;
 }
 
 pub struct MqCallMatcher;

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -930,6 +930,8 @@ impl Config for XcmConfig {
     type AssetTransactor = xcm_helper::XTransferAdapter<
         CurrencyTransactor,
         FungiblesTransactor,
+        XcmTransfer,
+        XcmTransfer,
         xcm_helper::NativeAssetFilter<ParachainInfo>,
         ChainBridge,
         BridgeTransfer,

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -899,6 +899,14 @@ parameter_types! {
         pha_per_second()
     );
 
+    pub FeePrices = [
+        ExecutionPriceInKSM,
+        ExecutionPriceInPHA,
+        ExecutionPriceInKAR,
+        ExecutionPriceInBNC,
+        ExecutionPriceInVKSM,
+    ];
+
     pub FeeAssets: MultiAssets = [
         KSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
         PHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
@@ -923,6 +931,8 @@ impl Config for XcmConfig {
         FungiblesTransactor,
         xcm_helper::NativeAssetFilter<ParachainInfo>,
         ChainBridge,
+        BridgeTransfer,
+        FeePrices,
     >;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = xcm_helper::AssetOriginFilter;

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -877,6 +877,7 @@ parameter_types! {
     pub KARAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::karura::ID), GeneralKey(parachains::karura::KAR_KEY.to_vec()))).into();
     pub BNCAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::BNC_KEY.to_vec()))).into();
     pub VSKSMAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::VSKSM_KEY.to_vec()))).into();
+    pub ZLKAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::ZLK_KEY.to_vec()))).into();
 
     pub ExecutionPriceInKSM: (AssetId, u128) = (
         KSMAssetId::get(),
@@ -892,11 +893,15 @@ parameter_types! {
     );
     pub ExecutionPriceInBNC: (AssetId, u128) = (
         BNCAssetId::get(),
-        pha_per_second() / 5
+        pha_per_second() / 4
     );
-    pub ExecutionPriceInVKSM: (AssetId, u128) = (
+    pub ExecutionPriceInVSKSM: (AssetId, u128) = (
         VSKSMAssetId::get(),
-        pha_per_second()
+        pha_per_second() / 600
+    );
+    pub ExecutionPriceInZLK: (AssetId, u128) = (
+        ZLKAssetId::get(),
+        pha_per_second() / 4
     );
 
     pub NativeExecutionPrice: u128 = pha_per_second();
@@ -905,7 +910,8 @@ parameter_types! {
         ExecutionPriceInPHA::get(),
         ExecutionPriceInKAR::get(),
         ExecutionPriceInBNC::get(),
-        ExecutionPriceInVKSM::get(),
+        ExecutionPriceInVSKSM::get(),
+        ExecutionPriceInZLK::get(),
     ].to_vec().into();
 
     pub FeeAssets: MultiAssets = [
@@ -914,6 +920,7 @@ parameter_types! {
         KARAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
         BNCAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
         VSKSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
+        ZLKAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
     ].to_vec().into();
 
     // This fee is set when we trying to send assets that dest chain not support
@@ -978,7 +985,15 @@ impl Config for XcmConfig {
             >,
         >,
         FixedRateOfFungible<
-            ExecutionPriceInVKSM,
+            ExecutionPriceInVSKSM,
+            xcm_helper::XTransferTakeRevenue<
+                Self::AssetTransactor,
+                AccountId,
+                KhalaTreasuryAccount,
+            >,
+        >,
+        FixedRateOfFungible<
+            ExecutionPriceInZLK,
             xcm_helper::XTransferTakeRevenue<
                 Self::AssetTransactor,
                 AccountId,

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -899,13 +899,14 @@ parameter_types! {
         pha_per_second()
     );
 
-    pub FeePrices = [
-        ExecutionPriceInKSM,
-        ExecutionPriceInPHA,
-        ExecutionPriceInKAR,
-        ExecutionPriceInBNC,
-        ExecutionPriceInVKSM,
-    ];
+    pub NativeExecutionPrice: u128 = pha_per_second();
+    pub ExecutionPrices: Vec<(AssetId, u128)> = [
+        ExecutionPriceInKSM::get(),
+        ExecutionPriceInPHA::get(),
+        ExecutionPriceInKAR::get(),
+        ExecutionPriceInBNC::get(),
+        ExecutionPriceInVKSM::get(),
+    ].to_vec().into();
 
     pub FeeAssets: MultiAssets = [
         KSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
@@ -932,7 +933,8 @@ impl Config for XcmConfig {
         xcm_helper::NativeAssetFilter<ParachainInfo>,
         ChainBridge,
         BridgeTransfer,
-        FeePrices,
+        AccountId,
+        KhalaTreasuryAccount,
     >;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = xcm_helper::AssetOriginFilter;
@@ -1362,6 +1364,9 @@ impl pallet_bridge_transfer::Config for Runtime {
     type Currency = Balances;
     type XcmTransactor = XcmTransfer;
     type OnFeePay = Treasury;
+    type NativeChecker = xcm_helper::NativeAssetFilter<ParachainInfo>;
+    type NativeExecutionPrice = NativeExecutionPrice;
+    type ExecutionPriceInfo = ExecutionPrices;
 }
 
 pub struct MqCallMatcher;


### PR DESCRIPTION
- Deduct fee when forwarding assets to solo chain.
- Pay asset itself as fee rather than PHA when transfering non-native assets to solo chains.
- Extra events added in xcm-transfer pallet.
- More information on chainbridge registry struct