### PR TITLE
Use whole asset amount as fee

### DIFF
--- a/pallets/xtransfer/src/xcm/xcm_transfer.rs
+++ b/pallets/xtransfer/src/xcm/xcm_transfer.rs
@@ -170,6 +170,27 @@ pub mod pallet {
 			T::Weigher::weight(&mut msg).map_or(Weight::max_value(), |w| w)
 		}
 
+		/// Calculate fee based on the asset
+		pub fn get_fee(asset: &MultiAsset) -> Option<MultiAsset> {
+			if T::FeeAssets::get().contains(&asset)
+				|| T::NativeAssetChecker::is_native_asset(&asset)
+			{
+				match asset.fun {
+					// Whole transfer amount be set as fee, actually fee spend depends one dest chain config
+					Fungible(_) => Some(asset.clone()),
+					// We do not support nonfungible asset transfer, nor support it as fee
+					_ => None,
+				}
+			} else {
+				// Basiclly, if the asset is supported as fee in our system, it should be also supported in the dest
+				// parachain, so if we are not support use this asset as fee, try use PHA as fee asset instead
+				Some(MultiAsset {
+					fun: Fungible(T::DefaultFee::get()),
+					id: T::NativeAssetChecker::native_asset_id().into(),
+				})
+			}
+		}
+
 		pub fn do_transfer_multiasset(
 			origin: MultiLocation,
 			asset: MultiAsset,
@@ -190,27 +211,7 @@ pub mod pallet {
 			};
 			ensure!(!recipient.is_none(), Error::<T>::IllegalDestination);
 
-			let fee = if T::FeeAssets::get().contains(&asset)
-				|| T::NativeAssetChecker::is_native_asset(&asset)
-			{
-				match asset.fun {
-					// So far only half of amount are allowed to be used as fee
-					Fungible(amount) => MultiAsset {
-						fun: Fungible(amount / 2),
-						id: asset.id.clone(),
-					},
-					// We do not support unfungible asset transfer, nor support it as fee
-					_ => return Err(Error::<T>::AssetNotFound.into()),
-				}
-			} else {
-				// Basiclly, if the asset is supported as fee in our system, it should be also supported in the dest
-				// parachain, so if we are not support use this asset as fee, try use PHA as fee asset instead
-				MultiAsset {
-					fun: Fungible(T::DefaultFee::get()),
-					id: T::NativeAssetChecker::native_asset_id().into(),
-				}
-			};
-
+			let fee = Self::get_fee(&asset).ok_or(Error::<T>::AssetNotFound)?;
 			let xcm_session = XCMSession::<T> {
 				asset: asset.clone(),
 				fee,


### PR DESCRIPTION
Note set whole asset amount as fee is the most effective way  to avoid insufficient fee payment on destination, we can do like this because XCM only deducte amount that spend by the execution, the rest of the fee will be deposited to recipient amount. It's more properly to estimate the fee when decimals, price and fee/ED configuration of the asset known on destination.