### PR TITLE
SubBridge dynamic trader

### DIFF
--- a/pallets/assets-registry/Cargo.toml
+++ b/pallets/assets-registry/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Phala-Network/phala-blockchain"
 codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive", "max-encoded-len"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive", "serde", "decode"] }
 log = { version = "0.4.14", default-features = false }
+hex-literal = "0.3.1"
 
 # Substrate
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }

--- a/pallets/assets-registry/Cargo.toml
+++ b/pallets/assets-registry/Cargo.toml
@@ -93,6 +93,7 @@ std = [
 	"frame-system/std",
 	"frame-benchmarking/std",
 	"pallet-balances/std",
+	"pallet-assets/std",
 	"parachains-common/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-utility/std",

--- a/pallets/assets-registry/src/lib.rs
+++ b/pallets/assets-registry/src/lib.rs
@@ -170,7 +170,7 @@ pub mod pallet {
 		type NativeExecutionPrice: Get<u128>;
 	}
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 	const LOG_TARGET: &str = "runtime::asset-registry";
 
 	type BalanceOf<T> =

--- a/pallets/assets-registry/src/lib.rs
+++ b/pallets/assets-registry/src/lib.rs
@@ -24,7 +24,7 @@ pub mod pallet {
 	use scale_info::TypeInfo;
 	use sp_runtime::traits::AccountIdConversion;
 	use sp_std::{boxed::Box, convert::From, vec, vec::Vec};
-	use xcm::latest::{prelude::*, MultiLocation};
+	use xcm::latest::{AssetId as XcmAssetId, prelude::*, MultiLocation};
 
 	/// Const used to indicate chainbridge path. str "cb"
 	pub const CB_ASSET_KEY: &[u8] = &[0x63, 0x62];
@@ -70,6 +70,7 @@ pub mod pallet {
 		fn id(location: &MultiLocation) -> Option<AssetId>;
 		fn lookup_by_resource_id(resource_id: &[u8; 32]) -> Option<MultiLocation>;
 		fn decimals(id: &AssetId) -> Option<u8>;
+		fn price(location: &MultiLocation) -> Option<(XcmAssetId, u128)>;
 	}
 
 	pub trait AccountId32Conversion {
@@ -485,6 +486,10 @@ pub mod pallet {
 
 		fn decimals(id: &<T as pallet_assets::Config>::AssetId) -> Option<u8> {
 			RegistryInfoByIds::<T>::get(&id).map(|m| m.properties.decimals)
+		}
+
+		fn price(_location: &MultiLocation) -> Option<(XcmAssetId, u128)> {
+			None
 		}
 	}
 

--- a/pallets/assets-registry/src/lib.rs
+++ b/pallets/assets-registry/src/lib.rs
@@ -509,7 +509,7 @@ pub mod pallet {
 		}
 
 		fn price(location: &MultiLocation) -> Option<(XcmAssetId, u128)> {
-			IdByLocation::<T>::get(location).and_then(|id| {
+			IdByLocations::<T>::get(location).and_then(|id| {
 				RegistryInfoByIds::<T>::get(&id).map(|m| {
 					(
 						m.location.into(),

--- a/pallets/assets-registry/src/lib.rs
+++ b/pallets/assets-registry/src/lib.rs
@@ -542,7 +542,7 @@ pub mod pallet {
 		fn price(location: &MultiLocation) -> Option<(XcmAssetId, u128)> {
 			// We should handle native asset specially because we never register it
 			if T::NativeAssetChecker::is_native_asset_location(location) {
-				return Some((MultiLocation::here().into(), T::NativeExecutionPrice::get()));
+				return Some((location.clone().into(), T::NativeExecutionPrice::get()));
 			}
 
 			IdByLocations::<T>::get(location).and_then(|id| {

--- a/pallets/assets-registry/src/lib.rs
+++ b/pallets/assets-registry/src/lib.rs
@@ -24,7 +24,7 @@ pub mod pallet {
 	use scale_info::TypeInfo;
 	use sp_runtime::traits::AccountIdConversion;
 	use sp_std::{boxed::Box, convert::From, vec, vec::Vec};
-	use xcm::latest::{AssetId as XcmAssetId, prelude::*, MultiLocation};
+	use xcm::latest::{prelude::*, AssetId as XcmAssetId, MultiLocation};
 
 	/// Const used to indicate chainbridge path. str "cb"
 	pub const CB_ASSET_KEY: &[u8] = &[0x63, 0x62];
@@ -64,6 +64,7 @@ pub mod pallet {
 		pub reserve_location: Option<MultiLocation>,
 		pub enabled_bridges: Vec<XBridge>,
 		pub properties: AssetProperties,
+		pub execution_price: Option<u128>,
 	}
 
 	pub trait GetAssetRegistryInfo<AssetId> {
@@ -165,6 +166,8 @@ pub mod pallet {
 		type Currency: Currency<Self::AccountId>;
 		#[pallet::constant]
 		type MinBalance: Get<<Self as pallet_assets::Config>::Balance>;
+		#[pallet::constant]
+		type NativeExecutionPrice: Get<u128>;
 	}
 
 	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
@@ -304,6 +307,7 @@ pub mod pallet {
 						metadata: Box::new(Vec::new()),
 					}],
 					properties: properties.clone(),
+					execution_price: None,
 				},
 			);
 			<pallet_assets::pallet::Pallet<T> as FungibleMutate<T::AccountId>>::set(
@@ -381,6 +385,22 @@ pub mod pallet {
 				properties.decimals,
 			)?;
 
+			Ok(())
+		}
+
+		#[pallet::weight(195_000_000)]
+		#[transactional]
+		pub fn force_set_price(
+			origin: OriginFor<T>,
+			asset_id: T::AssetId,
+			execution_price: u128,
+		) -> DispatchResult {
+			T::RegistryCommitteeOrigin::ensure_origin(origin.clone())?;
+
+			let mut info =
+				RegistryInfoByIds::<T>::get(&asset_id).ok_or(Error::<T>::AssetNotRegistered)?;
+			info.execution_price = Some(execution_price);
+			RegistryInfoByIds::<T>::insert(&asset_id, &info);
 			Ok(())
 		}
 
@@ -488,8 +508,15 @@ pub mod pallet {
 			RegistryInfoByIds::<T>::get(&id).map(|m| m.properties.decimals)
 		}
 
-		fn price(_location: &MultiLocation) -> Option<(XcmAssetId, u128)> {
-			None
+		fn price(location: &MultiLocation) -> Option<(XcmAssetId, u128)> {
+			IdByLocation::<T>::get(location).and_then(|id| {
+				RegistryInfoByIds::<T>::get(&id).map(|m| {
+					(
+						m.location.into(),
+						m.execution_price.unwrap_or(T::NativeExecutionPrice::get()),
+					)
+				})
+			})
 		}
 	}
 

--- a/pallets/assets-registry/src/lib.rs
+++ b/pallets/assets-registry/src/lib.rs
@@ -544,9 +544,8 @@ pub mod pallet {
 					.saturating_mul(10u128.saturating_pow(decimals as u32 - 12))
 					.into()
 			} else {
-				native_ed
-					.saturating_div(10u128.saturating_pow(12 - decimals as u32))
-					.into()
+				// + 1 make sure min balance always > 0
+				(native_ed.saturating_div(10u128.saturating_pow(12 - decimals as u32)) + 1).into()
 			}
 		}
 	}

--- a/pallets/assets-registry/src/migration.rs
+++ b/pallets/assets-registry/src/migration.rs
@@ -2,53 +2,68 @@ use super::*;
 
 mod assets_registry_v3_migration_common {
 	use super::*;
-	use frame_support::{ensure, traits::StorageVersion};
+	use codec::{Decode, Encode};
+	use frame_support::traits::StorageVersion;
+	use scale_info::TypeInfo;
+	use sp_std::vec::Vec;
+	use xcm::latest::MultiLocation;
+
+	#[derive(Clone, Decode, Encode, Eq, PartialEq, Ord, PartialOrd, Debug, TypeInfo)]
+	pub struct OldAssetRegistryInfo {
+		pub location: MultiLocation,
+		pub reserve_location: Option<MultiLocation>,
+		pub enabled_bridges: Vec<XBridge>,
+		pub properties: AssetProperties,
+	}
 
 	pub const EXPECTED_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 	pub const FINAL_STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
-	pub const KSM_PRICE: u128 = 111;
-	pub const KAR_PRICE: u128 = 111;
-	pub const BNC_PRICE: u128 = 111;
-	pub const ZLK_PRICE: u128 = 111;
-	pub const AUSD_PRICE: u128 = 111;
-	pub const BSX_PRICE: u128 = 111;
+	pub const PHA_PER_SECOND: u128 = 8_000_000_000;
+	pub const KSM_PRICE: u128 = PHA_PER_SECOND / 600;
+	pub const KAR_PRICE: u128 = PHA_PER_SECOND / 8;
+	pub const BNC_PRICE: u128 = PHA_PER_SECOND / 4;
+	pub const ZLK_PRICE: u128 = (PHA_PER_SECOND / 4) * 1_000_000; // decimals 18
+	pub const AUSD_PRICE: u128 = PHA_PER_SECOND / 8;
+	pub const BSX_PRICE: u128 = PHA_PER_SECOND;
+	pub const MOVR_PRICE: u128 = (PHA_PER_SECOND / 240) * 1_000_000; // decimals 18
+	pub const HKO_PRICE: u128 = PHA_PER_SECOND;
+
+	pub fn lookup_price<T: Config>(
+		assets: &[(<T as pallet_assets::Config>::AssetId, u128)],
+		asset_id: <T as pallet_assets::Config>::AssetId,
+	) -> Option<u128> {
+		for (id, price) in assets.iter() {
+			if *id == asset_id {
+				return Some(*price);
+			}
+		}
+		None
+	}
 
 	pub fn migrate_asset_price<T: Config>(
 		assets: &[(<T as pallet_assets::Config>::AssetId, u128)],
 	) -> frame_support::weights::Weight {
-		for (asset_id, execution_price) in assets.iter() {
-			let mut reg_info = RegistryInfoByIds::<T>::get(asset_id).unwrap();
-
-			reg_info.execution_price = Some(*execution_price);
-			RegistryInfoByIds::<T>::insert(asset_id, &reg_info);
-		}
+		RegistryInfoByIds::<T>::translate(
+			|asset_id: <T as pallet_assets::Config>::AssetId, old_info: OldAssetRegistryInfo| {
+				if let Some(execution_price) = lookup_price::<T>(assets, asset_id) {
+					Some(AssetRegistryInfo {
+						location: old_info.location,
+						reserve_location: old_info.reserve_location,
+						enabled_bridges: old_info.enabled_bridges,
+						properties: old_info.properties,
+						execution_price: Some(execution_price),
+					})
+				} else {
+					log::error!(
+						"Asset register info not found: ${:?}, would be deleted",
+						asset_id
+					);
+					None
+				}
+			},
+		);
 
 		assets.len() as u64
-	}
-
-	pub fn pre_check_price<T: Config>(
-		ids: &[<T as pallet_assets::Config>::AssetId],
-	) -> Result<(), &'static str> {
-		for asset_id in ids.iter() {
-			let reg_info =
-				RegistryInfoByIds::<T>::get(asset_id).ok_or(Error::<T>::AssetNotRegistered)?;
-			ensure!(reg_info.execution_price == None, "Incorrect registry info");
-		}
-		Ok(())
-	}
-
-	pub fn post_check_price<T: Config>(
-		assets: &[(<T as pallet_assets::Config>::AssetId, u128)],
-	) -> Result<(), &'static str> {
-		for (asset_id, price) in assets {
-			let reg_info =
-				RegistryInfoByIds::<T>::get(asset_id).ok_or(Error::<T>::AssetNotRegistered)?;
-			ensure!(
-				reg_info.execution_price == Some(*price),
-				"Incorrect registry info of KSM"
-			);
-		}
-		Ok(())
 	}
 }
 
@@ -70,16 +85,6 @@ pub mod assets_registry_v3_migration_for_rhala {
 			StorageVersion::get::<Pallet<T>>() == common::EXPECTED_STORAGE_VERSION,
 			"Incorrect AssetRegistry storage version in pre migrate"
 		);
-
-		let roc_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
-		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
-		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
-		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
-		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
-		let bsx_id: <T as pallet_assets::Config>::AssetId = 5u32.into();
-
-		common::pre_check_price::<T>(&[roc_id, kar_id, bnc_id, zlk_id, ausd_id, bsx_id])?;
-
 		log::info!("Assets registry pre migration check passed👏");
 
 		Ok(())
@@ -130,23 +135,6 @@ pub mod assets_registry_v3_migration_for_rhala {
 			StorageVersion::get::<Pallet<T>>() == common::FINAL_STORAGE_VERSION,
 			"Incorrect AssetRegistry storage version in post migrate"
 		);
-
-		let roc_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
-		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
-		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
-		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
-		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
-		let bsx_id: <T as pallet_assets::Config>::AssetId = 5u32.into();
-
-		common::post_check_price::<T>(&[
-			(roc_id, common::KSM_PRICE),
-			(kar_id, common::KAR_PRICE),
-			(bnc_id, common::BNC_PRICE),
-			(zlk_id, common::ZLK_PRICE),
-			(ausd_id, common::AUSD_PRICE),
-			(bsx_id, common::BSX_PRICE),
-		])?;
-
 		log::info!("Assets registry post migration check passed👏");
 
 		Ok(())
@@ -167,19 +155,10 @@ pub mod assets_registry_v3_migration_for_khala {
 		T: Config,
 		<T as pallet_assets::Config>::AssetId: From<u32>,
 	{
-		let ksm_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
-		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
-		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
-		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
-		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
-
-		common::pre_check_price::<T>(&[ksm_id, kar_id, bnc_id, zlk_id, ausd_id])?;
-
 		ensure!(
 			StorageVersion::get::<Pallet<T>>() == common::EXPECTED_STORAGE_VERSION,
 			"Incorrect AssetRegistry storage version in pre migrate"
 		);
-
 		log::info!("Assets registry pre migration check passed👏");
 
 		Ok(())
@@ -198,6 +177,9 @@ pub mod assets_registry_v3_migration_for_khala {
 			let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
 			let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
 			let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+			let bsx_id: <T as pallet_assets::Config>::AssetId = 5u32.into();
+			let movr_id: <T as pallet_assets::Config>::AssetId = 6u32.into();
+			let hko_id: <T as pallet_assets::Config>::AssetId = 7u32.into();
 
 			// Update execution prices
 			write_count += common::migrate_asset_price::<T>(&[
@@ -206,6 +188,9 @@ pub mod assets_registry_v3_migration_for_khala {
 				(bnc_id, common::BNC_PRICE),
 				(zlk_id, common::ZLK_PRICE),
 				(ausd_id, common::AUSD_PRICE),
+				(bsx_id, common::BSX_PRICE),
+				(movr_id, common::MOVR_PRICE),
+				(hko_id, common::HKO_PRICE),
 			]);
 
 			// Set new storage version
@@ -224,25 +209,10 @@ pub mod assets_registry_v3_migration_for_khala {
 		T: Config,
 		<T as pallet_assets::Config>::AssetId: From<u32>,
 	{
-		let ksm_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
-		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
-		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
-		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
-		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
-
 		ensure!(
 			StorageVersion::get::<Pallet<T>>() == common::FINAL_STORAGE_VERSION,
 			"Incorrect AssetRegistry storage version in post migrate"
 		);
-
-		common::post_check_price::<T>(&[
-			(ksm_id, common::KSM_PRICE),
-			(kar_id, common::KAR_PRICE),
-			(bnc_id, common::BNC_PRICE),
-			(zlk_id, common::ZLK_PRICE),
-			(ausd_id, common::AUSD_PRICE),
-		])?;
-
 		log::info!("Assets registry post migration check passed👏");
 
 		Ok(())

--- a/pallets/assets-registry/src/migration.rs
+++ b/pallets/assets-registry/src/migration.rs
@@ -47,6 +47,7 @@ pub mod assets_registry_migration {
 					metadata: Box::new(Vec::new()),
 				}],
 				properties: properties.clone(),
+				execution_price: None,
 			},
 		);
 

--- a/pallets/assets-registry/src/migration.rs
+++ b/pallets/assets-registry/src/migration.rs
@@ -1,131 +1,84 @@
 use super::*;
 
-pub mod assets_registry_migration {
+mod assets_registry_v3_migration_common {
 	use super::*;
+	use frame_support::{ensure, traits::StorageVersion};
+
+	pub const EXPECTED_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	pub const FINAL_STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	pub const KSM_PRICE: u128 = 111;
+	pub const KAR_PRICE: u128 = 111;
+	pub const BNC_PRICE: u128 = 111;
+	pub const ZLK_PRICE: u128 = 111;
+	pub const AUSD_PRICE: u128 = 111;
+	pub const BSX_PRICE: u128 = 111;
+
+	pub fn migrate_asset_price<T: Config>(
+		assets: &[(<T as pallet_assets::Config>::AssetId, u128)],
+	) -> frame_support::weights::Weight {
+		for (asset_id, execution_price) in assets.iter() {
+			let mut reg_info = RegistryInfoByIds::<T>::get(asset_id).unwrap();
+
+			reg_info.execution_price = Some(*execution_price);
+			RegistryInfoByIds::<T>::insert(asset_id, &reg_info);
+		}
+
+		assets.len() as u64
+	}
+
+	pub fn pre_check_price<T: Config>(
+		ids: &[<T as pallet_assets::Config>::AssetId],
+	) -> Result<(), &'static str> {
+		for asset_id in ids.iter() {
+			let reg_info =
+				RegistryInfoByIds::<T>::get(asset_id).ok_or(Error::<T>::AssetNotRegistered)?;
+			ensure!(reg_info.execution_price == None, "Incorrect registry info");
+		}
+		Ok(())
+	}
+
+	pub fn post_check_price<T: Config>(
+		assets: &[(<T as pallet_assets::Config>::AssetId, u128)],
+	) -> Result<(), &'static str> {
+		for (asset_id, price) in assets {
+			let reg_info =
+				RegistryInfoByIds::<T>::get(asset_id).ok_or(Error::<T>::AssetNotRegistered)?;
+			ensure!(
+				reg_info.execution_price == Some(*price),
+				"Incorrect registry info of KSM"
+			);
+		}
+		Ok(())
+	}
+}
+
+pub mod assets_registry_v3_migration_for_rhala {
+	use super::*;
+	use assets_registry_v3_migration_common as common;
 	use frame_support::{
 		ensure,
 		traits::{Get, StorageVersion},
 	};
 	use log;
-	use sp_std::{boxed::Box, vec, vec::Vec};
-	use xcm::latest::{prelude::*, MultiLocation};
-
-	const EXPECTED_STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
-	const FINAL_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
-
-	fn remove_assetswrapper_storage() -> frame_support::weights::Weight {
-		frame_support::migration::remove_storage_prefix(b"AssetsWrapper", b"IdByAssets", &[]);
-		frame_support::migration::remove_storage_prefix(b"AssetsWrapper", b"AssetByIds", &[]);
-		frame_support::migration::remove_storage_prefix(
-			b"AssetsWrapper",
-			b"AssetByResourceIds",
-			&[],
-		);
-		frame_support::migration::remove_storage_prefix(
-			b"AssetsWrapper",
-			b"RegistryInfoByIds",
-			&[],
-		);
-
-		4
-	}
-
-	fn migrate_asset_register<T: Config>(
-		location: MultiLocation,
-		asset_id: T::AssetId,
-		properties: AssetProperties,
-	) -> frame_support::weights::Weight {
-		IdByLocations::<T>::insert(&location, asset_id);
-		RegistryInfoByIds::<T>::insert(
-			asset_id,
-			AssetRegistryInfo {
-				location: location.clone(),
-				reserve_location: location.clone().reserve_location(),
-				// Xcmp will be enabled when assets being registered.
-				enabled_bridges: vec![XBridge {
-					config: XBridgeConfig::Xcmp,
-					metadata: Box::new(Vec::new()),
-				}],
-				properties: properties.clone(),
-				execution_price: None,
-			},
-		);
-
-		2
-	}
-
-	fn migrate_chainbridge<T: Config>(
-		asset_id: T::AssetId,
-		chain_id: u8,
-		is_mintable: bool,
-		metadata: Box<Vec<u8>>,
-	) -> frame_support::weights::Weight {
-		if let Some(mut info) = RegistryInfoByIds::<T>::get(&asset_id) {
-			let resource_id: [u8; 32] = info.location.clone().into_rid(chain_id);
-
-			IdByResourceId::<T>::insert(&resource_id, &asset_id);
-			// Save into registry info, here save chain id can not be added more than twice
-			let reserve_location: MultiLocation = (
-				0,
-				X2(
-					GeneralKey(CB_ASSET_KEY.to_vec()),
-					GeneralIndex(chain_id as u128),
-				),
-			)
-				.into();
-			info.enabled_bridges.push(XBridge {
-				config: XBridgeConfig::ChainBridge {
-					chain_id,
-					resource_id: resource_id.clone(),
-					reserve_account: reserve_location.into_account(),
-					is_mintable,
-				},
-				metadata,
-			});
-			RegistryInfoByIds::<T>::insert(&asset_id, &info);
-
-			2
-		} else {
-			0
-		}
-	}
 
 	pub fn pre_migrate<T>() -> Result<(), &'static str>
 	where
 		T: Config,
 		<T as pallet_assets::Config>::AssetId: From<u32>,
 	{
-		let ksm_id: T::AssetId = 0u32.into();
-		let kar_id: T::AssetId = 1u32.into();
-		let bnc_id: T::AssetId = 2u32.into();
-		let zlk_id: T::AssetId = 3u32.into();
-		let ausd_id: T::AssetId = 4u32.into();
-
 		ensure!(
-			RegistryInfoByIds::<T>::get(&ksm_id) == None,
-			"KSM already registered"
-		);
-		ensure!(
-			RegistryInfoByIds::<T>::get(&kar_id) == None,
-			"KAR already registered"
-		);
-		ensure!(
-			RegistryInfoByIds::<T>::get(&bnc_id) == None,
-			"BNC already registered"
-		);
-		ensure!(
-			RegistryInfoByIds::<T>::get(&zlk_id) == None,
-			"ZLK already registered"
-		);
-		ensure!(
-			RegistryInfoByIds::<T>::get(&ausd_id) == None,
-			"aUSD already registered"
-		);
-
-		ensure!(
-			StorageVersion::get::<Pallet<T>>() == EXPECTED_STORAGE_VERSION,
+			StorageVersion::get::<Pallet<T>>() == common::EXPECTED_STORAGE_VERSION,
 			"Incorrect AssetRegistry storage version in pre migrate"
 		);
+
+		let roc_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
+		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
+		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
+		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
+		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+		let bsx_id: <T as pallet_assets::Config>::AssetId = 5u32.into();
+
+		common::pre_check_price::<T>(&[roc_id, kar_id, bnc_id, zlk_id, ausd_id, bsx_id])?;
 
 		log::info!("Assets registry pre migration check passed👏");
 
@@ -137,78 +90,28 @@ pub mod assets_registry_migration {
 		T: Config,
 		<T as pallet_assets::Config>::AssetId: From<u32>,
 	{
-		if StorageVersion::get::<Pallet<T>>() == EXPECTED_STORAGE_VERSION {
+		if StorageVersion::get::<Pallet<T>>() == common::EXPECTED_STORAGE_VERSION {
 			log::info!("Start assets-registry migration");
 			let mut write_count = 0;
+			let roc_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
+			let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
+			let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
+			let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
+			let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+			let bsx_id: <T as pallet_assets::Config>::AssetId = 5u32.into();
 
-			// Clean storage items in old pallet
-			write_count += remove_assetswrapper_storage();
-
-			// Migrate KSM registry
-			write_count += migrate_asset_register::<T>(
-				MultiLocation::new(1, Here),
-				0u32.into(),
-				AssetProperties {
-					name: b"Kusama".to_vec(),
-					symbol: b"KSM".to_vec(),
-					decimals: 12,
-				},
-			);
-
-			// Migrate KAR registry
-			write_count += migrate_asset_register::<T>(
-				MultiLocation::new(1, X2(Parachain(2000), GeneralKey([0x0, 0x80].to_vec()))),
-				1u32.into(),
-				AssetProperties {
-					name: b"Karura".to_vec(),
-					symbol: b"KAR".to_vec(),
-					decimals: 12,
-				},
-			);
-
-			// Migrate BNC registry
-			write_count += migrate_asset_register::<T>(
-				MultiLocation::new(1, X2(Parachain(2001), GeneralKey([0x0, 0x01].to_vec()))),
-				2u32.into(),
-				AssetProperties {
-					name: b"Bifrost".to_vec(),
-					symbol: b"BNC".to_vec(),
-					decimals: 12,
-				},
-			);
-
-			// Migrate ZLK registry
-			write_count += migrate_asset_register::<T>(
-				MultiLocation::new(1, X2(Parachain(2001), GeneralKey([0x02, 0x07].to_vec()))),
-				3u32.into(),
-				AssetProperties {
-					name: b"Zenlink".to_vec(),
-					symbol: b"ZLK".to_vec(),
-					decimals: 18,
-				},
-			);
-
-			// Migrate aUSD registry
-			write_count += migrate_asset_register::<T>(
-				MultiLocation::new(1, X2(Parachain(2000), GeneralKey([0x0, 0x81].to_vec()))),
-				4u32.into(),
-				AssetProperties {
-					name: b"aUSD".to_vec(),
-					symbol: b"aUSD".to_vec(),
-					decimals: 12,
-				},
-			);
-
-			// Enable ZLK Chainbridge transfer
-			write_count += migrate_chainbridge::<T>(
-				3u32.into(),
-				2, // Moonriver
-				false,
-				Box::new(Vec::new()),
-			);
+			// Update execution prices
+			write_count += common::migrate_asset_price::<T>(&[
+				(roc_id, common::KSM_PRICE),
+				(kar_id, common::KAR_PRICE),
+				(bnc_id, common::BNC_PRICE),
+				(zlk_id, common::ZLK_PRICE),
+				(ausd_id, common::AUSD_PRICE),
+				(bsx_id, common::BSX_PRICE),
+			]);
 
 			// Set new storage version
-			StorageVersion::new(1).put::<Pallet<T>>();
+			StorageVersion::new(2).put::<Pallet<T>>();
 
 			log::info!("Assets registry migration done👏");
 
@@ -223,47 +126,123 @@ pub mod assets_registry_migration {
 		T: Config,
 		<T as pallet_assets::Config>::AssetId: From<u32>,
 	{
-		let ksm_id: T::AssetId = 0u32.into();
-		let kar_id: T::AssetId = 1u32.into();
-		let bnc_id: T::AssetId = 2u32.into();
-		let zlk_id: T::AssetId = 3u32.into();
-		let ausd_id: T::AssetId = 4u32.into();
-
 		ensure!(
-			StorageVersion::get::<Pallet<T>>() == FINAL_STORAGE_VERSION,
+			StorageVersion::get::<Pallet<T>>() == common::FINAL_STORAGE_VERSION,
 			"Incorrect AssetRegistry storage version in post migrate"
 		);
 
-		let ksm_info =
-			RegistryInfoByIds::<T>::get(&ksm_id).ok_or(Error::<T>::AssetNotRegistered)?;
+		let roc_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
+		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
+		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
+		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
+		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+		let bsx_id: <T as pallet_assets::Config>::AssetId = 5u32.into();
+
+		common::post_check_price::<T>(&[
+			(roc_id, common::KSM_PRICE),
+			(kar_id, common::KAR_PRICE),
+			(bnc_id, common::BNC_PRICE),
+			(zlk_id, common::ZLK_PRICE),
+			(ausd_id, common::AUSD_PRICE),
+			(bsx_id, common::BSX_PRICE),
+		])?;
+
+		log::info!("Assets registry post migration check passed👏");
+
+		Ok(())
+	}
+}
+
+pub mod assets_registry_v3_migration_for_khala {
+	use super::*;
+	use assets_registry_v3_migration_common as common;
+	use frame_support::{
+		ensure,
+		traits::{Get, StorageVersion},
+	};
+	use log;
+
+	pub fn pre_migrate<T>() -> Result<(), &'static str>
+	where
+		T: Config,
+		<T as pallet_assets::Config>::AssetId: From<u32>,
+	{
+		let ksm_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
+		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
+		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
+		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
+		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+
+		common::pre_check_price::<T>(&[ksm_id, kar_id, bnc_id, zlk_id, ausd_id])?;
+
 		ensure!(
-			&ksm_info.properties.symbol == b"KSM",
-			"Incorrect registry info of KSM"
+			StorageVersion::get::<Pallet<T>>() == common::EXPECTED_STORAGE_VERSION,
+			"Incorrect AssetRegistry storage version in pre migrate"
 		);
-		let kar_info =
-			RegistryInfoByIds::<T>::get(&kar_id).ok_or(Error::<T>::AssetNotRegistered)?;
+
+		log::info!("Assets registry pre migration check passed👏");
+
+		Ok(())
+	}
+
+	pub fn migrate<T>() -> frame_support::weights::Weight
+	where
+		T: Config,
+		<T as pallet_assets::Config>::AssetId: From<u32>,
+	{
+		if StorageVersion::get::<Pallet<T>>() == common::EXPECTED_STORAGE_VERSION {
+			log::info!("Start assets-registry migration");
+			let mut write_count = 0;
+			let ksm_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
+			let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
+			let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
+			let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
+			let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+
+			// Update execution prices
+			write_count += common::migrate_asset_price::<T>(&[
+				(ksm_id, common::KSM_PRICE),
+				(kar_id, common::KAR_PRICE),
+				(bnc_id, common::BNC_PRICE),
+				(zlk_id, common::ZLK_PRICE),
+				(ausd_id, common::AUSD_PRICE),
+			]);
+
+			// Set new storage version
+			StorageVersion::new(2).put::<Pallet<T>>();
+
+			log::info!("Assets registry migration done👏");
+
+			T::DbWeight::get().writes(write_count + 1)
+		} else {
+			T::DbWeight::get().reads(1)
+		}
+	}
+
+	pub fn post_migrate<T>() -> Result<(), &'static str>
+	where
+		T: Config,
+		<T as pallet_assets::Config>::AssetId: From<u32>,
+	{
+		let ksm_id: <T as pallet_assets::Config>::AssetId = 0u32.into();
+		let kar_id: <T as pallet_assets::Config>::AssetId = 1u32.into();
+		let bnc_id: <T as pallet_assets::Config>::AssetId = 2u32.into();
+		let zlk_id: <T as pallet_assets::Config>::AssetId = 3u32.into();
+		let ausd_id: <T as pallet_assets::Config>::AssetId = 4u32.into();
+
 		ensure!(
-			&kar_info.properties.symbol == b"KAR",
-			"Incorrect registry info of KAR"
+			StorageVersion::get::<Pallet<T>>() == common::FINAL_STORAGE_VERSION,
+			"Incorrect AssetRegistry storage version in post migrate"
 		);
-		let bnc_info =
-			RegistryInfoByIds::<T>::get(&bnc_id).ok_or(Error::<T>::AssetNotRegistered)?;
-		ensure!(
-			&bnc_info.properties.symbol == b"BNC",
-			"Incorrect registry info of BNC"
-		);
-		let zlk_info =
-			RegistryInfoByIds::<T>::get(&zlk_id).ok_or(Error::<T>::AssetNotRegistered)?;
-		ensure!(
-			&zlk_info.properties.symbol == b"ZLK",
-			"Incorrect registry info of ZLK"
-		);
-		let ausd_info =
-			RegistryInfoByIds::<T>::get(&ausd_id).ok_or(Error::<T>::AssetNotRegistered)?;
-		ensure!(
-			&ausd_info.properties.symbol == b"aUSD",
-			"Incorrect registry info of aUSD"
-		);
+
+		common::post_check_price::<T>(&[
+			(ksm_id, common::KSM_PRICE),
+			(kar_id, common::KAR_PRICE),
+			(bnc_id, common::BNC_PRICE),
+			(zlk_id, common::ZLK_PRICE),
+			(ausd_id, common::AUSD_PRICE),
+		])?;
+
 		log::info!("Assets registry post migration check passed👏");
 
 		Ok(())

--- a/pallets/assets-registry/src/migration.rs
+++ b/pallets/assets-registry/src/migration.rs
@@ -18,7 +18,9 @@ mod assets_registry_v3_migration_common {
 
 	pub const EXPECTED_STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 	pub const FINAL_STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
-	pub const PHA_PER_SECOND: u128 = 8_000_000_000;
+
+	// Calculated according to https://github.com/Phala-Network/khala-parachain/blob/06a0f84815d0666f72c4db65f7f794a854e5ee20/runtime/khala/src/constants.rs#L73
+	pub const PHA_PER_SECOND: u128 = 80_000_000_000_000;
 	pub const KSM_PRICE: u128 = PHA_PER_SECOND / 600;
 	pub const KAR_PRICE: u128 = PHA_PER_SECOND / 8;
 	pub const BNC_PRICE: u128 = PHA_PER_SECOND / 4;

--- a/pallets/assets-registry/src/mock.rs
+++ b/pallets/assets-registry/src/mock.rs
@@ -117,11 +117,15 @@ impl pallet_assets::Config for Test {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub NativeExecutionPrice: u128 = 1;
+}
 impl assets_registry::Config for Test {
 	type Event = Event;
 	type RegistryCommitteeOrigin = frame_system::EnsureRoot<Self::AccountId>;
 	type Currency = Balances;
 	type MinBalance = ExistentialDeposit;
+	type NativeExecutionPrice = NativeExecutionPrice;
 }
 
 impl pallet_timestamp::Config for Test {

--- a/pallets/assets-registry/src/mock.rs
+++ b/pallets/assets-registry/src/mock.rs
@@ -126,6 +126,7 @@ impl assets_registry::Config for Test {
 	type Currency = Balances;
 	type MinBalance = ExistentialDeposit;
 	type NativeExecutionPrice = NativeExecutionPrice;
+	type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
 }
 
 impl pallet_timestamp::Config for Test {

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -23,9 +23,7 @@ pub mod pallet {
 		convert::{From, Into, TryInto},
 		prelude::*,
 	};
-	use xcm::latest::{
-		prelude::*, Fungibility::Fungible, MultiAsset, MultiLocation,
-	};
+	use xcm::latest::{prelude::*, Fungibility::Fungible, MultiAsset, MultiLocation};
 	use xcm_executor::traits::TransactAsset;
 
 	const LOG_TARGET: &str = "runtime::chainbridge";

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -5,7 +5,7 @@ pub mod pallet {
 	use crate::traits::*;
 	use assets_registry::{
 		AccountId32Conversion, ExtractReserveLocation, GetAssetRegistryInfo, IntoResourceId,
-		CB_ASSET_KEY,
+		NativeAssetChecker, CB_ASSET_KEY,
 	};
 	use codec::{Decode, Encode, EncodeLike};
 	pub use frame_support::{

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -108,7 +108,7 @@ pub mod pallet {
 		}
 	}
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -797,24 +797,14 @@ pub mod pallet {
 		}
 
 		fn get_fee(chain_id: BridgeChainId, asset: &MultiAsset) -> Option<u128> {
-			if let Some((location, _amount)) = Self::extract_fungible(asset.clone()) {
-				if let Some(fee_in_pha) = Self::estimate_fee_in_pha(chain_id) {
-					if T::NativeAssetChecker::is_native_asset(asset) {
-						Some(fee_in_pha)
-					} else {
-						if let Some((_, execution_price)) = T::AssetsRegistry::price(&location) {
-							Some(Self::convert_fee_from_pha(fee_in_pha, execution_price))
-						} else {
-							None
-						}
-					}
-				} else {
-					None
-				}
-			} else {
-				None
-			}
 			// TODO: Calculate NonFungible asset fee
+			let (location, _amount) = Self::extract_fungible(asset.clone())?;
+			let fee_in_pha = Self::estimate_fee_in_pha(chain_id)?;
+			if T::NativeAssetChecker::is_native_asset(asset) {
+				return Some(fee_in_pha);
+			}
+			let (_, execution_price) = T::AssetsRegistry::price(&location)?;
+			Some(Self::convert_fee_from_pha(fee_in_pha, execution_price))
 		}
 
 		fn check_balance(sender: T::AccountId, asset: &MultiAsset, amount: u128) -> DispatchResult {

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -24,7 +24,7 @@ pub mod pallet {
 		prelude::*,
 	};
 	use xcm::latest::{
-		prelude::*, AssetId as XcmAssetId, Fungibility::Fungible, MultiAsset, MultiLocation,
+		prelude::*, Fungibility::Fungible, MultiAsset, MultiLocation,
 	};
 	use xcm_executor::traits::TransactAsset;
 
@@ -146,9 +146,6 @@ pub mod pallet {
 		/// Execution price in PHA
 		type NativeExecutionPrice: Get<u128>;
 
-		/// Execution price information
-		type ExecutionPriceInfo: Get<Vec<(XcmAssetId, u128)>>;
-
 		/// Treasury account to receive assets fee
 		type TreasuryAccount: Get<Self::AccountId>;
 
@@ -197,8 +194,7 @@ pub mod pallet {
 		ProposalFailed(BridgeChainId, DepositNonce),
 		FeeUpdated {
 			dest_id: BridgeChainId,
-			min_fee: u128,
-			fee_scale: u32,
+			fee: u128,
 		},
 	}
 
@@ -300,7 +296,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn bridge_fee)]
-	pub type BridgeFee<T: Config> = StorageMap<_, Twox64Concat, BridgeChainId, (u128, u32)>;
+	pub type BridgeFee<T: Config> = StorageMap<_, Twox64Concat, BridgeChainId, u128>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
@@ -373,18 +369,16 @@ pub mod pallet {
 		#[pallet::weight(195_000_000)]
 		pub fn update_fee(
 			origin: OriginFor<T>,
-			min_fee: u128,
-			fee_scale: u32,
+			fee: u128,
 			dest_id: BridgeChainId,
 		) -> DispatchResult {
 			T::BridgeCommitteeOrigin::ensure_origin(origin)?;
-			ensure!(fee_scale <= 1000u32, Error::<T>::InvalidFeeOption);
-			BridgeFee::<T>::insert(dest_id, (min_fee, fee_scale));
-			Self::deposit_event(Event::FeeUpdated {
-				dest_id,
-				min_fee,
-				fee_scale,
-			});
+			ensure!(
+				fee >= T::NativeExecutionPrice::get(),
+				Error::<T>::InvalidFeeOption
+			);
+			BridgeFee::<T>::insert(dest_id, fee);
+			Self::deposit_event(Event::FeeUpdated { dest_id, fee });
 			Ok(())
 		}
 
@@ -746,17 +740,8 @@ pub mod pallet {
 			}
 		}
 
-		pub fn estimate_fee_in_pha(dest_id: BridgeChainId, amount: u128) -> Option<u128> {
-			Self::bridge_fee(dest_id).map(|(min_fee, fee_scale)| {
-				let fee_estimated = amount
-					.saturating_mul(fee_scale as u128)
-					.saturating_div(1000u128);
-				if fee_estimated > min_fee {
-					fee_estimated
-				} else {
-					min_fee
-				}
-			})
+		pub fn estimate_fee_in_pha(dest_id: BridgeChainId) -> Option<u128> {
+			Self::bridge_fee(dest_id)
 		}
 
 		pub fn to_e12(amount: u128, decimals: u8) -> u128 {
@@ -775,9 +760,8 @@ pub mod pallet {
 			}
 		}
 
-		pub fn convert_fee_from_pha(fee_in_pha: u128, price: u128, decimals: u8) -> u128 {
-			let fee_e12: u128 = fee_in_pha * price / T::NativeExecutionPrice::get();
-			Self::from_e12(fee_e12, decimals)
+		pub fn convert_fee_from_pha(fee_in_pha: u128, price: u128) -> u128 {
+			fee_in_pha * price / T::NativeExecutionPrice::get()
 		}
 
 		pub fn rid_to_location(rid: &[u8; 32]) -> Result<MultiLocation, DispatchError> {
@@ -816,28 +800,15 @@ pub mod pallet {
 
 		fn get_fee(chain_id: BridgeChainId, asset: &MultiAsset) -> Option<u128> {
 			if let Some((location, amount)) = Self::extract_fungible(asset.clone()) {
-				let decimals = if T::NativeAssetChecker::is_native_asset(asset) {
-					12
-				} else {
-					let id = T::AssetsRegistry::id(&location.clone())?;
-					T::AssetsRegistry::decimals(&id).unwrap_or(12)
-				};
-				if let Some(fee_in_pha) =
-					Self::estimate_fee_in_pha(chain_id, (Self::to_e12(amount, decimals)).into())
-				{
+				if let Some(fee_in_pha) = Self::estimate_fee_in_pha(chain_id) {
 					if T::NativeAssetChecker::is_native_asset(asset) {
 						Some(fee_in_pha)
 					} else {
-						let fee_prices = T::ExecutionPriceInfo::get();
-						let fee_in_asset = fee_prices
-							.iter()
-							.position(|(fee_asset_id, _)| {
-								fee_asset_id == &Concrete(location.clone())
-							})
-							.map(|idx| {
-								Self::convert_fee_from_pha(fee_in_pha, fee_prices[idx].1, decimals)
-							});
-						fee_in_asset
+						if let Some((_, execution_price)) = T::AssetsRegistry::price(&location) {
+							Some(Self::convert_fee_from_pha(fee_in_pha, execution_price))
+						} else {
+							None
+						}
 					}
 				} else {
 					None
@@ -1609,7 +1580,7 @@ pub mod pallet {
 				let recipient = vec![99];
 
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), dest_chain));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 2, dest_chain));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, dest_chain));
 
 				let bridge_impl = BridgeTransactImpl::<Runtime>::new();
 				assert_noop!(
@@ -1651,7 +1622,7 @@ pub mod pallet {
 				let recipient = vec![99];
 
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), dest_chain));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 2, dest_chain));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, dest_chain));
 
 				// Register asset, id = 0
 				assert_ok!(AssetsRegistry::force_register_asset(
@@ -1714,7 +1685,7 @@ pub mod pallet {
 				let recipient = vec![99];
 
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), dest_chain));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 2, dest_chain));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, dest_chain));
 
 				// Register asset, id = 0
 				assert_ok!(AssetsRegistry::force_register_asset(
@@ -1793,7 +1764,7 @@ pub mod pallet {
 				let recipient = vec![99];
 
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), dest_chain));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 2, dest_chain));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, dest_chain));
 
 				// Register asset, id = 0
 				assert_ok!(AssetsRegistry::force_register_asset(
@@ -1805,6 +1776,12 @@ pub mod pallet {
 						symbol: b"BA".to_vec(),
 						decimals: 12,
 					},
+				));
+				// Set execution price of asset, price is 2 * NativeExecutionPrice * 10^(12 - 12)
+				assert_ok!(AssetsRegistry::force_set_price(
+					Origin::root(),
+					0,
+					NativeExecutionPrice::get() * 2,
 				));
 
 				// Setup solo chain for this asset
@@ -1866,7 +1843,7 @@ pub mod pallet {
 				let recipient = vec![99];
 
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), dest_chain));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 2, dest_chain));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, dest_chain));
 
 				let bridge_impl = BridgeTransactImpl::<Runtime>::new();
 				assert_noop!(
@@ -2321,8 +2298,15 @@ pub mod pallet {
 
 			ParaA::execute_with(|| {
 				let dest_chain: u8 = 2;
+				let bridge_fee = 2;
 				let test_asset_location = MultiLocation::new(1, X1(GeneralKey(b"test".to_vec())));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 0, dest_chain));
+				let unregistered_asset_location =
+					MultiLocation::new(1, X1(GeneralKey(b"unregistered".to_vec())));
+				assert_ok!(ChainBridge::update_fee(
+					Origin::root(),
+					bridge_fee,
+					dest_chain
+				));
 
 				// Register asset, decimals: 18, rate with pha: 1 : 1
 				assert_ok!(AssetsRegistry::force_register_asset(
@@ -2335,6 +2319,12 @@ pub mod pallet {
 						decimals: 18,
 					},
 				));
+				// Set execution price of asset, price is 1 * NativeExecutionPrice * 10^(18-12)
+				assert_ok!(AssetsRegistry::force_set_price(
+					Origin::root(),
+					0,
+					NativeExecutionPrice::get() * 1_000_000,
+				));
 				// Register asset, decimals: 12, rate with pha: 1 : 2
 				assert_ok!(AssetsRegistry::force_register_asset(
 					Origin::root(),
@@ -2346,8 +2336,14 @@ pub mod pallet {
 						decimals: 12,
 					},
 				));
+				// Set execution price of asset, price is 2 * NativeExecutionPrice * 10^(12 - 12)
+				assert_ok!(AssetsRegistry::force_set_price(
+					Origin::root(),
+					1,
+					NativeExecutionPrice::get() * 2,
+				));
 
-				// Register asset, decimals: 12, not set as fee payment
+				// Register asset, decimals: 12, not set as fee payment, should be treat same as PHA
 				assert_ok!(AssetsRegistry::force_register_asset(
 					Origin::root(),
 					test_asset_location.clone().into(),
@@ -2370,9 +2366,16 @@ pub mod pallet {
 				)
 					.into();
 				let test_asset: MultiAsset = (test_asset_location, Fungible(100)).into();
+				let unregistered_asset: MultiAsset =
+					(unregistered_asset_location, Fungible(100)).into();
 
-				// Test asset not configured as fee payment in trader
-				assert_eq!(ChainBridge::get_fee(dest_chain, &test_asset), None);
+				// Unregistered asset fee should return None
+				assert_eq!(ChainBridge::get_fee(dest_chain, &unregistered_asset), None);
+				// Test asset not configured as fee payment in trader, execution price would would be set same with PHA
+				assert_eq!(
+					ChainBridge::get_fee(dest_chain, &test_asset),
+					Some(bridge_fee)
+				);
 				// Fee in pha is 2, decimal of balance is not set so will be set as 12 when calculating fee,
 				// asset 0 decimals is 18, and rate with pha is 1:1
 				// Final fee in asset 0 is 2_000_000

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -797,7 +797,7 @@ pub mod pallet {
 		}
 
 		fn get_fee(chain_id: BridgeChainId, asset: &MultiAsset) -> Option<u128> {
-			if let Some((location, amount)) = Self::extract_fungible(asset.clone()) {
+			if let Some((location, _amount)) = Self::extract_fungible(asset.clone()) {
 				if let Some(fee_in_pha) = Self::estimate_fee_in_pha(chain_id) {
 					if T::NativeAssetChecker::is_native_asset(asset) {
 						Some(fee_in_pha)

--- a/pallets/subbridge/src/chainbridge.rs
+++ b/pallets/subbridge/src/chainbridge.rs
@@ -2300,11 +2300,6 @@ pub mod pallet {
 				let test_asset_location = MultiLocation::new(1, X1(GeneralKey(b"test".to_vec())));
 				let unregistered_asset_location =
 					MultiLocation::new(1, X1(GeneralKey(b"unregistered".to_vec())));
-				assert_ok!(ChainBridge::update_fee(
-					Origin::root(),
-					bridge_fee,
-					dest_chain
-				));
 
 				// Register asset, decimals: 18, rate with pha: 1 : 1
 				assert_ok!(AssetsRegistry::force_register_asset(
@@ -2367,6 +2362,11 @@ pub mod pallet {
 				let unregistered_asset: MultiAsset =
 					(unregistered_asset_location, Fungible(100)).into();
 
+				assert_ok!(ChainBridge::update_fee(
+					Origin::root(),
+					bridge_fee,
+					dest_chain
+				));
 				// Unregistered asset fee should return None
 				assert_eq!(ChainBridge::get_fee(dest_chain, &unregistered_asset), None);
 				// Test asset not configured as fee payment in trader, execution price would would be set same with PHA

--- a/pallets/subbridge/src/dynamic_trader.rs
+++ b/pallets/subbridge/src/dynamic_trader.rs
@@ -1,6 +1,6 @@
 use assets_registry::GetAssetRegistryInfo;
 use frame_support::weights::{constants::WEIGHT_PER_SECOND, Weight};
-use sp_std::{marker::PhantomData, result::Result};
+use sp_std::{marker::PhantomData, result::Result, vec::Vec};
 use xcm::latest::{prelude::*, AssetId};
 use xcm_builder::TakeRevenue;
 use xcm_executor::{traits::WeightTrader, Assets};

--- a/pallets/subbridge/src/dynamic_trader.rs
+++ b/pallets/subbridge/src/dynamic_trader.rs
@@ -1,0 +1,104 @@
+use assets_registry::GetAssetRegistryInfo;
+use frame_support::weights::{constants::WEIGHT_PER_SECOND, Weight};
+use sp_std::{marker::PhantomData, result::Result};
+use xcm::latest::{prelude::*, AssetId};
+use xcm_builder::TakeRevenue;
+use xcm_executor::{traits::WeightTrader, Assets};
+
+pub struct DynamicWeightTrader<FungibleAssetId, FungibleAssetsInfo, R>(
+	Weight,
+	u128,
+	Option<(AssetId, u128)>,
+	PhantomData<(FungibleAssetId, FungibleAssetsInfo, R)>,
+);
+impl<FungibleAssetId, FungibleAssetsInfo, R> WeightTrader
+	for DynamicWeightTrader<FungibleAssetId, FungibleAssetsInfo, R>
+where
+	FungibleAssetsInfo: GetAssetRegistryInfo<FungibleAssetId>,
+	R: TakeRevenue,
+{
+	fn new() -> Self {
+		Self(0, 0, None, PhantomData)
+	}
+
+	fn buy_weight(&mut self, weight: Weight, payment: Assets) -> Result<Assets, XcmError> {
+		log::trace!(
+			target: "xtranfer::weight",
+			"DynamicWeightTrader::buy_weight weight: {:?}, payment: {:?}",
+			weight, payment.clone(),
+		);
+
+		let payment_assets: Vec<MultiAsset> = payment.clone().into();
+		let mut last_error = None;
+		for payment_asset in payment_assets.iter() {
+			match (&payment_asset.id, &payment_asset.fun) {
+				(Concrete(ref location), Fungible(_)) => {
+					// We found an asset that can be pay as fee from the registered asset list
+					if let Some((id, units_per_second)) = FungibleAssetsInfo::price(&location) {
+						let amount =
+							units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+						if amount == 0 {
+							return Ok(payment.clone());
+						}
+
+						// Note unused must contain asset that not used to pay fee, so here we deduct fee
+						// from `payment` rather than `payment_asset`
+						match payment.clone().checked_sub((id.clone(), amount).into()) {
+							Ok(unused) => {
+								self.0 = self.0.saturating_add(weight);
+								self.1 = self.1.saturating_add(amount);
+								self.2 = Some((id.clone(), units_per_second));
+								log::trace!(
+									target: "xtranfer::weight",
+									"DynamicWeightTrader::successfully by weight: {:?}, amount: {:?}, asset id: {:?}",
+									weight, amount, id,
+								);
+								return Ok(unused);
+							}
+							Err(_) => last_error = Some(XcmError::TooExpensive),
+						}
+					} else {
+						last_error = Some(XcmError::TooExpensive);
+					}
+				}
+                // Only fungible assets can be used to by weight
+				_ => last_error = Some(XcmError::TooExpensive),
+			}
+		}
+
+		Err(last_error.unwrap_or(XcmError::AssetNotFound))
+	}
+
+	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+		log::trace!(target: "xtranfer::weight", "DynamicWeightTrader::refund_weight weight: {:?}", weight);
+
+		// If we have deducted some fee from payment assets
+		if let Some((id, units_per_second)) = &self.2 {
+			let weight = weight.min(self.0);
+			let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+			self.0 -= weight;
+			self.1 = self.1.saturating_sub(amount);
+			if amount > 0 {
+				Some((id.clone(), amount).into())
+			} else {
+				None
+			}
+		} else {
+			None
+		}
+	}
+}
+
+impl<FungibleAssetId, FungibleAssetsInfo, R> Drop
+	for DynamicWeightTrader<FungibleAssetId, FungibleAssetsInfo, R>
+where
+	FungibleAssetsInfo: GetAssetRegistryInfo<FungibleAssetId>,
+	R: TakeRevenue,
+{
+	fn drop(&mut self) {
+		if self.1 > 0 {
+			let (id, _) = self.2.expect("Unexpected weight payment result; qed.");
+			R::take_revenue((id, self.1).into());
+		}
+	}
+}

--- a/pallets/subbridge/src/dynamic_trader.rs
+++ b/pallets/subbridge/src/dynamic_trader.rs
@@ -22,7 +22,7 @@ pub struct DynamicWeightTrader<
 impl<WeightPerSecond, FungibleAssetId, FungibleAssetsInfo, R> WeightTrader
 	for DynamicWeightTrader<WeightPerSecond, FungibleAssetId, FungibleAssetsInfo, R>
 where
-	WeightPerSecond: Get<u128>,
+	WeightPerSecond: Get<u64>,
 	FungibleAssetsInfo: GetAssetRegistryInfo<FungibleAssetId>,
 	R: TakeRevenue,
 {
@@ -44,7 +44,8 @@ where
 				(Concrete(ref location), Fungible(_)) => {
 					// We found an asset that can be pay as fee from the registered asset list
 					if let Some((id, units_per_second)) = FungibleAssetsInfo::price(&location) {
-						let amount = units_per_second * (weight as u128) / WeightPerSecond::get();
+						let amount =
+							units_per_second * (weight as u128) / (WeightPerSecond::get() as u128);
 						if amount == 0 {
 							return Ok(payment.clone());
 						}

--- a/pallets/subbridge/src/dynamic_trader.rs
+++ b/pallets/subbridge/src/dynamic_trader.rs
@@ -73,11 +73,7 @@ where
 				_ => last_error = Some(XcmError::TooExpensive),
 			}
 		}
-		println!(
-			"DynamicWeightTrader::buy_weight failed, weight: {:?}, payment: {:?}",
-			weight,
-			payment.clone(),
-		);
+
 		Err(last_error.unwrap_or(XcmError::AssetNotFound))
 	}
 

--- a/pallets/subbridge/src/fungible_adapter.rs
+++ b/pallets/subbridge/src/fungible_adapter.rs
@@ -1,5 +1,5 @@
 use crate::traits::*;
-use assets_registry::AccountId32Conversion;
+use assets_registry::{AccountId32Conversion, NativeAssetChecker};
 use sp_std::{convert::Into, marker::PhantomData, result, vec::Vec};
 use xcm::latest::{prelude::*, Error as XcmError, MultiAsset, MultiLocation, Result as XcmResult};
 use xcm_executor::{traits::TransactAsset, Assets};

--- a/pallets/subbridge/src/helper.rs
+++ b/pallets/subbridge/src/helper.rs
@@ -1,4 +1,3 @@
-use crate::traits::*;
 use assets_registry::{GetAssetRegistryInfo, NativeAssetChecker};
 use frame_support::pallet_prelude::*;
 use sp_runtime::traits::CheckedConversion;

--- a/pallets/subbridge/src/helper.rs
+++ b/pallets/subbridge/src/helper.rs
@@ -1,6 +1,5 @@
 use crate::traits::*;
-use assets_registry::GetAssetRegistryInfo;
-use cumulus_primitives_core::ParaId;
+use assets_registry::{GetAssetRegistryInfo, NativeAssetChecker};
 use frame_support::pallet_prelude::*;
 use sp_runtime::traits::CheckedConversion;
 use sp_std::{
@@ -58,29 +57,6 @@ impl FilterAssetLocation for AssetOriginFilter {
 			}
 		}
 		false
-	}
-}
-
-pub struct NativeAssetFilter<T>(PhantomData<T>);
-impl<T: Get<ParaId>> NativeAssetChecker for NativeAssetFilter<T> {
-	fn is_native_asset(asset: &MultiAsset) -> bool {
-		match (&asset.id, &asset.fun) {
-			// So far our native asset is concrete
-			(Concrete(ref id), Fungible(_)) if Self::is_native_asset_location(id) => true,
-			_ => false,
-		}
-	}
-
-	fn is_native_asset_location(id: &MultiLocation) -> bool {
-		let native_locations = [
-			MultiLocation::here(),
-			(1, X1(Parachain(T::get().into()))).into(),
-		];
-		native_locations.contains(id)
-	}
-
-	fn native_asset_location() -> MultiLocation {
-		(1, X1(Parachain(T::get().into()))).into()
 	}
 }
 

--- a/pallets/subbridge/src/lib.rs
+++ b/pallets/subbridge/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod chainbridge;
+pub mod dynamic_trader;
 pub mod fungible_adapter;
 pub mod helper;
 mod mock;

--- a/pallets/subbridge/src/migration.rs
+++ b/pallets/subbridge/src/migration.rs
@@ -66,8 +66,8 @@ pub mod subbridge_migration {
 			frame_support::migration::remove_storage_prefix(b"ChainBridge", b"Resources", &[]);
 
 			// Create new storage items of fee setting in pallet ChainBridge
-			chainbridge::BridgeFee::<T>::insert(0, (300_000_000_000_000, 0));
-			chainbridge::BridgeFee::<T>::insert(2, (1_000_000_000_000, 0));
+			chainbridge::BridgeFee::<T>::insert(0, 300_000_000_000_000);
+			chainbridge::BridgeFee::<T>::insert(2, 1_000_000_000_000);
 
 			// Set new storage version
 			StorageVersion::new(2).put::<chainbridge::Pallet<T>>();

--- a/pallets/subbridge/src/migration.rs
+++ b/pallets/subbridge/src/migration.rs
@@ -1,6 +1,6 @@
 use crate::{chainbridge, xcmbridge, xtransfer};
 
-pub mod subbridge_migration {
+pub mod subbridge_v3_migration {
 	use super::*;
 	use frame_support::{
 		ensure,
@@ -17,15 +17,15 @@ pub mod subbridge_migration {
 	);
 
 	const EXPECTED_STORAGE_VERSION: Versions = (
-		StorageVersion::new(0),
+		StorageVersion::new(1),
 		StorageVersion::new(0),
 		StorageVersion::new(0),
 	);
 
 	const FINAL_STORAGE_VERSION: Versions = (
-		StorageVersion::new(2),
-		StorageVersion::new(2),
-		StorageVersion::new(2),
+		StorageVersion::new(3),
+		StorageVersion::new(3),
+		StorageVersion::new(3),
 	);
 
 	fn get_versions<T>() -> Versions
@@ -43,6 +43,7 @@ pub mod subbridge_migration {
 	where
 		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
 	{
+		log::info!("Subbridge current version: {:?}", get_versions::<T>());
 		ensure!(
 			get_versions::<T>() == EXPECTED_STORAGE_VERSION,
 			"Incorrect subbridge storage version in pre migrate"
@@ -57,27 +58,22 @@ pub mod subbridge_migration {
 	{
 		if get_versions::<T>() == EXPECTED_STORAGE_VERSION {
 			log::info!("Start subbridge migration");
-			let mut weight = 0;
-			// Clean storage exist in removed pallet BridgeTransfer
-			frame_support::migration::remove_storage_prefix(b"BridgeTransfer", b"BridgeFee", &[]);
 
-			// Clean torage used to save resource id in ChainBridge
-			// see issue: https://github.com/Phala-Network/khala-parachain/issues/60
-			frame_support::migration::remove_storage_prefix(b"ChainBridge", b"Resources", &[]);
+			// Remove old chainbridge::BridgeFee storage
+			frame_support::migration::remove_storage_prefix(b"BridgeTransfer", b"BridgeFee", &[]);
 
 			// Create new storage items of fee setting in pallet ChainBridge
 			chainbridge::BridgeFee::<T>::insert(0, 300_000_000_000_000);
 			chainbridge::BridgeFee::<T>::insert(2, 1_000_000_000_000);
 
 			// Set new storage version
-			StorageVersion::new(2).put::<chainbridge::Pallet<T>>();
-			StorageVersion::new(2).put::<xcmbridge::Pallet<T>>();
-			StorageVersion::new(2).put::<xtransfer::Pallet<T>>();
+			StorageVersion::new(3).put::<chainbridge::Pallet<T>>();
+			StorageVersion::new(3).put::<xcmbridge::Pallet<T>>();
+			StorageVersion::new(3).put::<xtransfer::Pallet<T>>();
 
 			log::info!("Subbridge migration done👏");
 
-			weight += T::DbWeight::get().writes(7);
-			weight
+			T::DbWeight::get().writes(6)
 		} else {
 			T::DbWeight::get().reads(1)
 		}

--- a/pallets/subbridge/src/migration.rs
+++ b/pallets/subbridge/src/migration.rs
@@ -1,13 +1,10 @@
 use crate::{chainbridge, xcmbridge, xtransfer};
 
-pub mod subbridge_v3_migration {
+mod subbridge_v3_migration_common {
 	use super::*;
-	use frame_support::{
-		ensure,
-		traits::{Get, StorageVersion},
-	};
+	use frame_support::traits::StorageVersion;
 
-	type Versions = (
+	pub type Versions = (
 		// Version of chainbridge
 		StorageVersion,
 		// Version of xcmbridge
@@ -16,19 +13,25 @@ pub mod subbridge_v3_migration {
 		StorageVersion,
 	);
 
-	const EXPECTED_STORAGE_VERSION: Versions = (
+	pub const EXPECTED_RHALA_STORAGE_VERSION: Versions = (
 		StorageVersion::new(1),
 		StorageVersion::new(0),
 		StorageVersion::new(0),
 	);
 
-	const FINAL_STORAGE_VERSION: Versions = (
+	pub const EXPECTED_KHALA_STORAGE_VERSION: Versions = (
+		StorageVersion::new(2),
+		StorageVersion::new(2),
+		StorageVersion::new(2),
+	);
+
+	pub const FINAL_STORAGE_VERSION: Versions = (
 		StorageVersion::new(3),
 		StorageVersion::new(3),
 		StorageVersion::new(3),
 	);
 
-	fn get_versions<T>() -> Versions
+	pub fn get_versions<T>() -> Versions
 	where
 		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
 	{
@@ -39,13 +42,37 @@ pub mod subbridge_v3_migration {
 		)
 	}
 
+	pub fn do_migration<T>() -> frame_support::weights::Weight
+	where
+		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
+	{
+		// Remove old chainbridge::BridgeFee storage
+		frame_support::migration::remove_storage_prefix(b"ChainBridge", b"BridgeFee", &[]);
+
+		// Create new storage items of fee setting in pallet ChainBridge
+		chainbridge::BridgeFee::<T>::insert(0, 300_000_000_000_000);
+		chainbridge::BridgeFee::<T>::insert(2, 1_000_000_000_000);
+
+		// Set new storage version
+		StorageVersion::new(3).put::<chainbridge::Pallet<T>>();
+		StorageVersion::new(3).put::<xcmbridge::Pallet<T>>();
+		StorageVersion::new(3).put::<xtransfer::Pallet<T>>();
+
+		6
+	}
+}
+
+pub mod subbridge_v3_migration_for_rhala {
+	use super::*;
+	use frame_support::{ensure, traits::Get};
+	use subbridge_v3_migration_common as common;
+
 	pub fn pre_migrate<T>() -> Result<(), &'static str>
 	where
 		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
 	{
-		log::info!("Subbridge current version: {:?}", get_versions::<T>());
 		ensure!(
-			get_versions::<T>() == EXPECTED_STORAGE_VERSION,
+			common::get_versions::<T>() == common::EXPECTED_RHALA_STORAGE_VERSION,
 			"Incorrect subbridge storage version in pre migrate"
 		);
 		log::info!("Subbridge pre migration check passed👏");
@@ -56,24 +83,14 @@ pub mod subbridge_v3_migration {
 	where
 		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
 	{
-		if get_versions::<T>() == EXPECTED_STORAGE_VERSION {
+		if common::get_versions::<T>() == common::EXPECTED_RHALA_STORAGE_VERSION {
 			log::info!("Start subbridge migration");
 
-			// Remove old chainbridge::BridgeFee storage
-			frame_support::migration::remove_storage_prefix(b"BridgeTransfer", b"BridgeFee", &[]);
-
-			// Create new storage items of fee setting in pallet ChainBridge
-			chainbridge::BridgeFee::<T>::insert(0, 300_000_000_000_000);
-			chainbridge::BridgeFee::<T>::insert(2, 1_000_000_000_000);
-
-			// Set new storage version
-			StorageVersion::new(3).put::<chainbridge::Pallet<T>>();
-			StorageVersion::new(3).put::<xcmbridge::Pallet<T>>();
-			StorageVersion::new(3).put::<xtransfer::Pallet<T>>();
+			let write_count = common::do_migration::<T>();
 
 			log::info!("Subbridge migration done👏");
 
-			T::DbWeight::get().writes(6)
+			T::DbWeight::get().writes(write_count)
 		} else {
 			T::DbWeight::get().reads(1)
 		}
@@ -84,7 +101,55 @@ pub mod subbridge_v3_migration {
 		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
 	{
 		ensure!(
-			get_versions::<T>() == FINAL_STORAGE_VERSION,
+			common::get_versions::<T>() == common::FINAL_STORAGE_VERSION,
+			"Incorrect subbridge storage version in post migrate"
+		);
+		log::info!("Subbridge post migration check passed👏");
+
+		Ok(())
+	}
+}
+
+pub mod subbridge_v3_migration_for_khala {
+	use super::*;
+	use frame_support::{ensure, traits::Get};
+	use subbridge_v3_migration_common as common;
+
+	pub fn pre_migrate<T>() -> Result<(), &'static str>
+	where
+		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
+	{
+		ensure!(
+			common::get_versions::<T>() == common::EXPECTED_KHALA_STORAGE_VERSION,
+			"Incorrect subbridge storage version in pre migrate"
+		);
+		log::info!("Subbridge pre migration check passed👏");
+		Ok(())
+	}
+
+	pub fn migrate<T>() -> frame_support::weights::Weight
+	where
+		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
+	{
+		if common::get_versions::<T>() == common::EXPECTED_KHALA_STORAGE_VERSION {
+			log::info!("Start subbridge migration");
+
+			let write_count = common::do_migration::<T>();
+
+			log::info!("Subbridge migration done👏");
+
+			T::DbWeight::get().writes(write_count)
+		} else {
+			T::DbWeight::get().reads(1)
+		}
+	}
+
+	pub fn post_migrate<T>() -> Result<(), &'static str>
+	where
+		T: chainbridge::Config + xcmbridge::Config + xtransfer::Config,
+	{
+		ensure!(
+			common::get_versions::<T>() == common::FINAL_STORAGE_VERSION,
 			"Incorrect subbridge storage version in post migrate"
 		);
 		log::info!("Subbridge post migration check passed👏");

--- a/pallets/subbridge/src/mock/para.rs
+++ b/pallets/subbridge/src/mock/para.rs
@@ -372,6 +372,7 @@ impl assets_registry::Config for Runtime {
 	type RegistryCommitteeOrigin = EnsureRoot<AccountId>;
 	type Currency = Balances;
 	type MinBalance = AssetDeposit;
+	type NativeExecutionPrice = NativeExecutionPrice;
 }
 
 impl chainbridge::Config for Runtime {

--- a/pallets/subbridge/src/mock/para.rs
+++ b/pallets/subbridge/src/mock/para.rs
@@ -161,21 +161,6 @@ parameter_types! {
 	pub ParaBLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(2)));
 	pub ParaCLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(3)));
 
-	pub KSMAssetId: AssetId = KSMLocation::get().into();
-	pub LocalAssetId: AssetId = LocalParaLocation::get().into();
-	pub ParaAAssetId: AssetId = ParaALocation::get().into();
-	pub ParaBAssetId: AssetId = ParaBLocation::get().into();
-	pub ParaCAssetId: AssetId = ParaCLocation::get().into();
-
-	pub FeeAssets: MultiAssets = [
-		KSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-		LocalAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-		ParaAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-		ParaBAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-		ParaCAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-	].to_vec().into();
-
-	pub const DefaultDestChainXcmFee: Balance = 10;
 	pub TREASURY: AccountId32 = AccountId32::new([4u8; 32]);
 		// We define two test assets to simulate tranfer assets to reserve location and unreserve location,
 	// we must defiend here because those need be configed as fee payment assets
@@ -362,8 +347,6 @@ impl xcmbridge::Config for Runtime {
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type FeeAssets = FeeAssets;
-	type DefaultFee = DefaultDestChainXcmFee;
 	type AssetsRegistry = AssetsRegistry;
 }
 
@@ -384,7 +367,6 @@ impl chainbridge::Config for Runtime {
 	type ProposalLifetime = ProposalLifetime;
 	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
 	type NativeExecutionPrice = NativeExecutionPrice;
-	type ExecutionPriceInfo = ExecutionPrices;
 	type TreasuryAccount = TREASURY;
 	type FungibleAdapter = XTransferAdapter<
 		CurrencyTransactor,

--- a/pallets/subbridge/src/mock/para.rs
+++ b/pallets/subbridge/src/mock/para.rs
@@ -179,7 +179,7 @@ parameter_types! {
 		),
 	);
 	pub NativeExecutionPrice: u128 = 1;
-	pub WeightPerSecond: u128 = 1;
+	pub WeightPerSecond: u64 = 1;
 }
 
 pub type LocationToAccountId = (

--- a/pallets/subbridge/src/traits.rs
+++ b/pallets/subbridge/src/traits.rs
@@ -115,8 +115,3 @@ pub trait OnDeposited {
 pub trait OnForwarded {
 	fn on_forwarded(what: MultiAsset, who: MultiLocation, memo: Vec<u8>) -> DispatchResult;
 }
-pub trait NativeAssetChecker {
-	fn is_native_asset(asset: &MultiAsset) -> bool;
-	fn is_native_asset_location(id: &MultiLocation) -> bool;
-	fn native_asset_location() -> MultiLocation;
-}

--- a/pallets/subbridge/src/xcmbridge.rs
+++ b/pallets/subbridge/src/xcmbridge.rs
@@ -19,7 +19,7 @@ pub mod pallet {
 
 	/// The logging target.
 	const LOG_TARGET: &str = "runtime::xcm-transfer";
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/pallets/subbridge/src/xcmbridge.rs
+++ b/pallets/subbridge/src/xcmbridge.rs
@@ -367,7 +367,7 @@ pub mod pallet {
 			let (dest_location, beneficiary) =
 				Pallet::<T>::extract_dest(&dest).ok_or(Error::<T>::IllegalDestination)?;
 
-			// We can not grantee asset has been supported by destination
+			// We can not guarantee the asset has been supported by destination
 			let fee = asset.clone();
 
 			let xcm_session = XCMSession::<T> {

--- a/pallets/subbridge/src/xcmbridge.rs
+++ b/pallets/subbridge/src/xcmbridge.rs
@@ -4,7 +4,7 @@ pub use self::pallet::*;
 pub mod pallet {
 	use crate::helper::*;
 	use crate::traits::*;
-	use assets_registry::GetAssetRegistryInfo;
+	use assets_registry::{GetAssetRegistryInfo, NativeAssetChecker};
 	use frame_support::{
 		dispatch::DispatchResult,
 		pallet_prelude::*,
@@ -462,6 +462,8 @@ pub mod pallet {
 						decimals: 12,
 					},
 				));
+				// ParaB set price of the native asset of paraA
+				assert_ok!(AssetsRegistry::force_set_price(para::Origin::root(), 0, 1,));
 			});
 
 			ParaA::execute_with(|| {
@@ -513,6 +515,8 @@ pub mod pallet {
 						decimals: 12,
 					},
 				));
+				// ParaB set price of the native asset of paraA
+				assert_ok!(AssetsRegistry::force_set_price(para::Origin::root(), 0, 1,));
 			});
 
 			ParaA::execute_with(|| {

--- a/pallets/subbridge/src/xcmbridge.rs
+++ b/pallets/subbridge/src/xcmbridge.rs
@@ -58,12 +58,6 @@ pub mod pallet {
 		/// Filter native asset
 		type NativeAssetChecker: NativeAssetChecker;
 
-		/// Assets that can be used to pay xcm execution
-		type FeeAssets: Get<MultiAssets>;
-
-		/// Default xcm fee(PHA) used to buy execution on dest parachain
-		type DefaultFee: Get<u128>;
-
 		/// Fungible assets registry
 		type AssetsRegistry: GetAssetRegistryInfo<<Self as pallet_assets::Config>::AssetId>;
 	}
@@ -301,26 +295,6 @@ pub mod pallet {
 				_ => None,
 			}
 		}
-
-		pub fn get_fee(asset: &MultiAsset) -> Option<MultiAsset> {
-			if T::FeeAssets::get().contains(&asset)
-				|| T::NativeAssetChecker::is_native_asset(&asset)
-			{
-				match asset.fun {
-					// Whole transfer amount be set as fee, actually fee spend depends one dest chain config
-					Fungible(_) => Some(asset.clone()),
-					// We do not support nonfungible asset transfer, nor support it as fee
-					_ => None,
-				}
-			} else {
-				// Basiclly, if the asset is supported as fee in our system, it should be also supported in the dest
-				// parachain, so if we are not support use this asset as fee, try use PHA as fee asset instead
-				Some(MultiAsset {
-					fun: Fungible(T::DefaultFee::get()),
-					id: T::NativeAssetChecker::native_asset_location().into(),
-				})
-			}
-		}
 	}
 
 	impl<T: Config> BridgeChecker for Pallet<T>
@@ -393,7 +367,8 @@ pub mod pallet {
 			let (dest_location, beneficiary) =
 				Pallet::<T>::extract_dest(&dest).ok_or(Error::<T>::IllegalDestination)?;
 
-			let fee = Pallet::<T>::get_fee(&asset).ok_or(Error::<T>::AssetNotFound)?;
+			// We can not grantee asset has been supported by destination
+			let fee = asset.clone();
 
 			let xcm_session = XCMSession::<T> {
 				asset: asset.clone(),

--- a/pallets/subbridge/src/xtransfer.rs
+++ b/pallets/subbridge/src/xtransfer.rs
@@ -12,7 +12,7 @@ pub mod pallet {
 	use sp_std::{boxed::Box, convert::From, vec::Vec};
 	use xcm::latest::{prelude::*, MultiAsset, MultiLocation};
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]

--- a/pallets/subbridge/src/xtransfer.rs
+++ b/pallets/subbridge/src/xtransfer.rs
@@ -568,6 +568,8 @@ pub mod pallet {
 						decimals: 12,
 					},
 				));
+				// ParaB set price of the native asset of paraA
+				assert_ok!(AssetsRegistry::force_set_price(para::Origin::root(), 0, 1,));
 			});
 
 			ParaA::execute_with(|| {

--- a/pallets/subbridge/src/xtransfer.rs
+++ b/pallets/subbridge/src/xtransfer.rs
@@ -377,7 +377,7 @@ pub mod pallet {
 			ParaA::execute_with(|| {
 				// Set bridge fee and whitelist chain for the dest chain
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), 0));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 0, 0));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 0));
 
 				// To solochains via Chainbridge(according to the dest)
 				assert_ok!(XTransfer::transfer(
@@ -438,6 +438,12 @@ pub mod pallet {
 						decimals: 12,
 					},
 				));
+				// Set execution price of asset, price is 2 * NativeExecutionPrice * 10^(12 - 12)
+				assert_ok!(AssetsRegistry::force_set_price(
+					Origin::root(),
+					0,
+					para::NativeExecutionPrice::get() * 2,
+				));
 
 				// Enable Chainbridge bridge for the asset
 				assert_ok!(AssetsRegistry::force_enable_chainbridge(
@@ -459,7 +465,7 @@ pub mod pallet {
 
 				// Set bridge fee and whitelist chain for the dest chain
 				assert_ok!(ChainBridge::whitelist_chain(Origin::root(), 0));
-				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 0, 0));
+				assert_ok!(ChainBridge::update_fee(Origin::root(), 2, 0));
 
 				// To solochains via Chainbridge(according to the dest)
 				assert_ok!(XTransfer::transfer(

--- a/pallets/subbridge/src/xtransfer.rs
+++ b/pallets/subbridge/src/xtransfer.rs
@@ -597,7 +597,7 @@ pub mod pallet {
 				assert_eq!(Assets::balance(0u32.into(), &BOB), 10 - 1);
 			});
 
-			// Now, let's transfer back to paraA use xtransfer instread of xcm_transfer
+			// Now, let's transfer back to paraA use xtransfer instread of xcm bridge
 			ParaB::execute_with(|| {
 				// ParaB send back ParaA's native asset
 				assert_ok!(XTransfer::transfer(

--- a/runtime/khala/src/constants.rs
+++ b/runtime/khala/src/constants.rs
@@ -78,33 +78,3 @@ pub mod fee {
         base_tx_fee * tx_per_second
     }
 }
-
-pub mod parachains {
-    pub mod karura {
-        pub const ID: u32 = 2000;
-        pub const KAR_KEY: [u8; 2] = [0, 128];
-        pub const KUSD_KEY: [u8; 2] = [0, 129];
-    }
-
-    pub mod bifrost {
-        pub const ID: u32 = 2001;
-        pub const BNC_KEY: &[u8] = &[0, 1];
-        pub const VSKSM_KEY: &[u8] = &[4, 4];
-        pub const ZLK_KEY: &[u8] = &[2, 7];
-    }
-
-    pub mod moonriver {
-        pub const ID: u32 = 2023;
-        pub const MOVR_INSTANCE: u8 = 10;
-    }
-
-    pub mod heiko {
-        pub const ID: u32 = 2085;
-        pub const HKO_KEY: &[u8] = &[72, 75, 79]; // "HKO"
-    }
-
-    pub mod basilisk {
-        pub const ID: u32 = 2090;
-        pub const BSX_KEY: &[u8] = &[0, 0, 0, 0];
-    }
-}

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -840,7 +840,7 @@ pub type CurrencyTransactor = CurrencyAdapter<
     // Use this currency:
     Balances,
     // Use this currency when it is a fungible asset matching the given location or name:
-    helper::NativeAssetMatcher<helper::NativeAssetFilter<ParachainInfo>>,
+    helper::NativeAssetMatcher<assets_registry::NativeAssetFilter<ParachainInfo>>,
     // Convert an XCM MultiLocation into a local account id:
     LocationToAccountId,
     // Our chain's account ID type (we can't get away without mentioning it explicitly):
@@ -946,7 +946,7 @@ impl Config for XcmConfig {
         CurrencyTransactor,
         FungiblesTransactor,
         XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
+        assets_registry::NativeAssetFilter<ParachainInfo>,
     >;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = helper::AssetOriginFilter;
@@ -1066,7 +1066,7 @@ impl xcmbridge::Config for Runtime {
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
     type LocationInverter = LocationInverter<Ancestry>;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
     type AssetsRegistry = AssetsRegistry;
 }
 
@@ -1076,6 +1076,7 @@ impl assets_registry::Config for Runtime {
     type Currency = Balances;
     type MinBalance = ExistentialDeposit;
     type NativeExecutionPrice = NativeExecutionPrice;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
 }
 
 parameter_types! {
@@ -1389,14 +1390,14 @@ impl chainbridge::Config for Runtime {
     type BridgeChainId = BridgeChainId;
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
     type NativeExecutionPrice = NativeExecutionPrice;
     type TreasuryAccount = KhalaTreasuryAccount;
     type FungibleAdapter = XTransferAdapter<
         CurrencyTransactor,
         FungiblesTransactor,
         XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
+        assets_registry::NativeAssetFilter<ParachainInfo>,
     >;
     type AssetsRegistry = AssetsRegistry;
 }

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1105,6 +1105,7 @@ impl assets_registry::Config for Runtime {
     type RegistryCommitteeOrigin = EnsureRootOrHalfCouncil;
     type Currency = Balances;
     type MinBalance = ExistentialDeposit;
+    type NativeExecutionPrice = NativeExecutionPrice;
 }
 
 parameter_types! {

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -931,38 +931,6 @@ parameter_types! {
     );
 
     pub NativeExecutionPrice: u128 = pha_per_second();
-    pub ExecutionPrices: Vec<(AssetId, u128)> = [
-        ExecutionPriceInKSM::get(),
-        ExecutionPriceInPHA::get(),
-        ExecutionPriceInLocalPHA::get(),
-        ExecutionPriceInKAR::get(),
-        ExecutionPriceInKUSD::get(),
-        ExecutionPriceInBNC::get(),
-        ExecutionPriceInVSKSM::get(),
-        ExecutionPriceInZLK::get(),
-        ExecutionPriceInMOVR::get(),
-        ExecutionPriceInHKO::get(),
-        ExecutionPriceInBSX::get(),
-    ].to_vec().into();
-
-    pub FeeAssets: MultiAssets = [
-        KSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        PHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        LocalPHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        KARAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        KUSDAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        BNCAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        VSKSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        ZLKAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        MOVRAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        HKOAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        BSXAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-    ].to_vec().into();
-
-    // This fee is set when we trying to send assets that dest chain not support
-    // it as trade fee, thus we set PHA as the fee asset, and give this default
-    // amount to pay fee.
-    pub const DefaultDestChainXcmFee: Balance = 10 * CENTS;
 }
 
 pub struct XcmConfig;
@@ -1085,19 +1053,17 @@ impl pallet_xcm::Config for Runtime {
     type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl xcmbridge::Config for Runtime {
-    type Event = Event;
-    type Currency = Balances;
-    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmRouter = XcmRouter;
-    type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-    type LocationInverter = LocationInverter<Ancestry>;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-    type FeeAssets = FeeAssets;
-    type DefaultFee = DefaultDestChainXcmFee;
-    type AssetsRegistry = AssetsRegistry;
+impl xcm_transfer::Config for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+	type AssetsRegistry = AssetsRegistry;
 }
 
 impl assets_registry::Config for Runtime {
@@ -1420,16 +1386,15 @@ impl chainbridge::Config for Runtime {
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
     type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-    type NativeExecutionPrice = NativeExecutionPrice;
-    type ExecutionPriceInfo = ExecutionPrices;
-    type TreasuryAccount = KhalaTreasuryAccount;
-    type FungibleAdapter = XTransferAdapter<
-        CurrencyTransactor,
-        FungiblesTransactor,
-        XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
-    >;
-    type AssetsRegistry = AssetsRegistry;
+	type NativeExecutionPrice = NativeExecutionPrice;
+	type TreasuryAccount = KhalaTreasuryAccount;
+	type FungibleAdapter = XTransferAdapter<
+		CurrencyTransactor,
+		FungiblesTransactor,
+		XTransfer,
+		helper::NativeAssetFilter<ParachainInfo>,
+	>;
+	type AssetsRegistry = AssetsRegistry;
 }
 
 impl xtransfer::Config for Runtime {

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1053,7 +1053,7 @@ impl pallet_xcm::Config for Runtime {
     type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl xcm_transfer::Config for Runtime {
+impl xcmbridge::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1054,16 +1054,16 @@ impl pallet_xcm::Config for Runtime {
 }
 
 impl xcm_transfer::Config for Runtime {
-	type Event = Event;
-	type Currency = Balances;
-	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmRouter = XcmRouter;
-	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type LocationInverter = LocationInverter<Ancestry>;
-	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type AssetsRegistry = AssetsRegistry;
+    type Event = Event;
+    type Currency = Balances;
+    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    type XcmRouter = XcmRouter;
+    type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    type XcmExecutor = XcmExecutor<XcmConfig>;
+    type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+    type LocationInverter = LocationInverter<Ancestry>;
+    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type AssetsRegistry = AssetsRegistry;
 }
 
 impl assets_registry::Config for Runtime {
@@ -1386,15 +1386,15 @@ impl chainbridge::Config for Runtime {
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
     type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type NativeExecutionPrice = NativeExecutionPrice;
-	type TreasuryAccount = KhalaTreasuryAccount;
-	type FungibleAdapter = XTransferAdapter<
-		CurrencyTransactor,
-		FungiblesTransactor,
-		XTransfer,
-		helper::NativeAssetFilter<ParachainInfo>,
-	>;
-	type AssetsRegistry = AssetsRegistry;
+    type NativeExecutionPrice = NativeExecutionPrice;
+    type TreasuryAccount = KhalaTreasuryAccount;
+    type FungibleAdapter = XTransferAdapter<
+        CurrencyTransactor,
+        FungiblesTransactor,
+        XTransfer,
+        helper::NativeAssetFilter<ParachainInfo>,
+    >;
+    type AssetsRegistry = AssetsRegistry;
 }
 
 impl xtransfer::Config for Runtime {

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -42,7 +42,6 @@ pub mod constants;
 use constants::{
     currency::*,
     fee::{pha_per_second, WeightToFee},
-    parachains,
 };
 
 mod migrations;
@@ -88,8 +87,8 @@ use polkadot_parachain::primitives::Sibling;
 use xcm::latest::prelude::*;
 use xcm_builder::{
     AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-    AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible,
-    FixedWeightBounds, FungiblesAdapter, LocationInverter, ParentIsPreset, RelayChainAsNative,
+    AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
+    FungiblesAdapter, LocationInverter, ParentIsPreset, RelayChainAsNative,
     SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
     SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 };
@@ -100,7 +99,8 @@ pub use parachains_common::*;
 
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
 pub use subbridge_pallets::{
-    chainbridge, fungible_adapter::XTransferAdapter, helper, xcmbridge, xtransfer,
+    chainbridge, dynamic_trader::DynamicWeightTrader, fungible_adapter::XTransferAdapter, helper,
+    xcmbridge, xtransfer,
 };
 
 #[cfg(any(feature = "std", test))]
@@ -877,64 +877,8 @@ pub type FungiblesTransactor = FungiblesAdapter<
 >;
 
 parameter_types! {
-    pub KSMAssetId: AssetId = MultiLocation::new(1, Here).into();
-    pub PHAAssetId: AssetId = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into()))).into();
-    pub LocalPHAAssetId: AssetId = MultiLocation::new(0, Here).into();
-    pub KARAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::karura::ID), GeneralKey(parachains::karura::KAR_KEY.to_vec()))).into();
-    pub KUSDAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::karura::ID), GeneralKey(parachains::karura::KUSD_KEY.to_vec()))).into();
-    pub BNCAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::BNC_KEY.to_vec()))).into();
-    pub VSKSMAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::VSKSM_KEY.to_vec()))).into();
-    pub ZLKAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::ZLK_KEY.to_vec()))).into();
-    pub MOVRAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::moonriver::ID), PalletInstance(parachains::moonriver::MOVR_INSTANCE))).into();
-    pub HKOAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::heiko::ID), GeneralKey(parachains::heiko::HKO_KEY.to_vec()))).into();
-    pub BSXAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::basilisk::ID), GeneralKey(parachains::basilisk::BSX_KEY.to_vec()))).into();
-
-    pub ExecutionPriceInKSM: (AssetId, u128) = (
-        KSMAssetId::get(),
-        pha_per_second() / 600
-    );
-    pub ExecutionPriceInPHA: (AssetId, u128) = (
-        PHAAssetId::get(),
-        pha_per_second()
-    );
-    pub ExecutionPriceInLocalPHA: (AssetId, u128) = (
-        LocalPHAAssetId::get(),
-        pha_per_second()
-    );
-    pub ExecutionPriceInKAR: (AssetId, u128) = (
-        KARAssetId::get(),
-        pha_per_second() / 8
-    );
-    pub ExecutionPriceInKUSD: (AssetId, u128) = (
-        KUSDAssetId::get(),
-        pha_per_second() / 4
-    );
-    pub ExecutionPriceInBNC: (AssetId, u128) = (
-        BNCAssetId::get(),
-        pha_per_second() / 4
-    );
-    pub ExecutionPriceInVSKSM: (AssetId, u128) = (
-        VSKSMAssetId::get(),
-        pha_per_second() / 600
-    );
-    pub ExecutionPriceInZLK: (AssetId, u128) = (
-        ZLKAssetId::get(),
-        pha_per_second() / 4
-    );
-    pub ExecutionPriceInMOVR: (AssetId, u128) = (
-        MOVRAssetId::get(),
-        pha_per_second() / 240
-    );
-    pub ExecutionPriceInHKO: (AssetId, u128) = (
-        HKOAssetId::get(),
-        pha_per_second()
-    );
-    pub ExecutionPriceInBSX: (AssetId, u128) = (
-        BSXAssetId::get(),
-        pha_per_second()
-    );
-
     pub NativeExecutionPrice: u128 = pha_per_second();
+    pub WeightPerSecond: u64 = WEIGHT_PER_SECOND;
 }
 
 pub struct XcmConfig;
@@ -954,52 +898,12 @@ impl Config for XcmConfig {
     type LocationInverter = LocationInverter<Ancestry>;
     type Barrier = Barrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-    type Trader = (
-        FixedRateOfFungible<
-            ExecutionPriceInKSM,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInPHA,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInLocalPHA,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInKAR,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInKUSD,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInBNC,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInVSKSM,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInZLK,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInHKO,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInMOVR,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInBSX,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
-        >,
-    );
+    type Trader = DynamicWeightTrader<
+        WeightPerSecond,
+        <Runtime as pallet_assets::Config>::AssetId,
+        AssetsRegistry,
+        helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, KhalaTreasuryAccount>,
+    >;
     type ResponseHandler = PolkadotXcm;
     type AssetTrap = PolkadotXcm;
     type AssetClaims = PolkadotXcm;

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -187,6 +187,10 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    (
+        migrations::SubbridgeV3Migrations,
+        migrations::AssetsRegistryV2Migrations,
+    ),
 >;
 
 type EnsureRootOrHalfCouncil = EnsureOneOf<

--- a/runtime/khala/src/migrations.rs
+++ b/runtime/khala/src/migrations.rs
@@ -6,17 +6,17 @@ pub struct SubbridgeV3Migrations;
 
 impl OnRuntimeUpgrade for SubbridgeV3Migrations {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        subbridge_pallets::migration::subbridge_v3_migration::migrate::<Runtime>()
+        subbridge_pallets::migration::subbridge_v3_migration_for_khala::migrate::<Runtime>()
     }
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<(), &'static str> {
-        subbridge_pallets::migration::subbridge_v3_migration::pre_migrate::<Runtime>()
+        subbridge_pallets::migration::subbridge_v3_migration_for_khala::pre_migrate::<Runtime>()
     }
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        subbridge_pallets::migration::subbridge_v3_migration::post_migrate::<Runtime>()
+        subbridge_pallets::migration::subbridge_v3_migration_for_khala::post_migrate::<Runtime>()
     }
 }
 

--- a/runtime/khala/src/migrations.rs
+++ b/runtime/khala/src/migrations.rs
@@ -34,6 +34,7 @@ impl OnRuntimeUpgrade for AssetsRegistryV2Migrations {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        assets_registry::migration::assets_registry_v3_migration_for_khala::post_migrate::<Runtime>()
+        assets_registry::migration::assets_registry_v3_migration_for_khala::post_migrate::<Runtime>(
+        )
     }
 }

--- a/runtime/khala/src/migrations.rs
+++ b/runtime/khala/src/migrations.rs
@@ -2,3 +2,38 @@
 use super::*;
 #[allow(unused_imports)]
 use frame_support::traits::OnRuntimeUpgrade;
+pub struct SubbridgeV3Migrations;
+
+impl OnRuntimeUpgrade for SubbridgeV3Migrations {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        subbridge_pallets::migration::subbridge_v3_migration::migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<(), &'static str> {
+        subbridge_pallets::migration::subbridge_v3_migration::pre_migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade() -> Result<(), &'static str> {
+        subbridge_pallets::migration::subbridge_v3_migration::post_migrate::<Runtime>()
+    }
+}
+
+pub struct AssetsRegistryV2Migrations;
+
+impl OnRuntimeUpgrade for AssetsRegistryV2Migrations {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        assets_registry::migration::assets_registry_v3_migration_for_khala::migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<(), &'static str> {
+        assets_registry::migration::assets_registry_v3_migration_for_khala::pre_migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade() -> Result<(), &'static str> {
+        assets_registry::migration::assets_registry_v3_migration_for_khala::post_migrate::<Runtime>()
+    }
+}

--- a/runtime/rhala/src/constants.rs
+++ b/runtime/rhala/src/constants.rs
@@ -78,33 +78,3 @@ pub mod fee {
         base_tx_fee * tx_per_second
     }
 }
-
-pub mod parachains {
-    pub mod karura {
-        pub const ID: u32 = 2000;
-        pub const KAR_KEY: [u8; 2] = [0, 128];
-        pub const KUSD_KEY: [u8; 2] = [0, 129];
-    }
-
-    pub mod bifrost {
-        pub const ID: u32 = 2001;
-        pub const BNC_KEY: &[u8] = &[0, 1];
-        pub const VSKSM_KEY: &[u8] = &[4, 4];
-        pub const ZLK_KEY: &[u8] = &[2, 7];
-    }
-
-    pub mod moonbase {
-        pub const ID: u32 = 1000;
-        pub const DEV_INSTANCE: u8 = 3;
-    }
-
-    pub mod heiko {
-        pub const ID: u32 = 2085;
-        pub const HKO_KEY: &[u8] = &[72, 75, 79]; // "HKO"
-    }
-
-    pub mod basilisk {
-        pub const ID: u32 = 2090;
-        pub const BSX_KEY: &[u8] = &[0, 0, 0, 0];
-    }
-}

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -189,6 +189,10 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    (
+        migrations::SubbridgeV3Migrations,
+        migrations::AssetsRegistryV2Migrations,
+    ),
 >;
 
 type EnsureRootOrHalfCouncil = EnsureOneOf<

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1056,7 +1056,7 @@ impl pallet_xcm::Config for Runtime {
     type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl xcm_transfer::Config for Runtime {
+impl xcmbridge::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -847,7 +847,7 @@ pub type CurrencyTransactor = CurrencyAdapter<
     // Use this currency:
     Balances,
     // Use this currency when it is a fungible asset matching the given location or name:
-    helper::NativeAssetMatcher<helper::NativeAssetFilter<ParachainInfo>>,
+    helper::NativeAssetMatcher<assets_registry::NativeAssetFilter<ParachainInfo>>,
     // Convert an XCM MultiLocation into a local account id:
     LocationToAccountId,
     // Our chain's account ID type (we can't get away without mentioning it explicitly):
@@ -953,7 +953,7 @@ impl Config for XcmConfig {
         CurrencyTransactor,
         FungiblesTransactor,
         XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
+        assets_registry::NativeAssetFilter<ParachainInfo>,
     >;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = helper::AssetOriginFilter;
@@ -1069,7 +1069,7 @@ impl xcmbridge::Config for Runtime {
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
     type LocationInverter = LocationInverter<Ancestry>;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
     type AssetsRegistry = AssetsRegistry;
 }
 
@@ -1079,6 +1079,7 @@ impl assets_registry::Config for Runtime {
     type Currency = Balances;
     type MinBalance = ExistentialDeposit;
     type NativeExecutionPrice = NativeExecutionPrice;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
 }
 
 parameter_types! {
@@ -1392,14 +1393,14 @@ impl chainbridge::Config for Runtime {
     type BridgeChainId = BridgeChainId;
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
     type NativeExecutionPrice = NativeExecutionPrice;
     type TreasuryAccount = RhalaTreasuryAccount;
     type FungibleAdapter = XTransferAdapter<
         CurrencyTransactor,
         FungiblesTransactor,
         XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
+        assets_registry::NativeAssetFilter<ParachainInfo>,
     >;
     type AssetsRegistry = AssetsRegistry;
 }

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -42,7 +42,6 @@ pub mod constants;
 use constants::{
     currency::*,
     fee::{pha_per_second, WeightToFee},
-    parachains,
 };
 
 mod migrations;
@@ -88,8 +87,8 @@ use polkadot_parachain::primitives::Sibling;
 use xcm::latest::prelude::*;
 use xcm_builder::{
     AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-    AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible,
-    FixedWeightBounds, FungiblesAdapter, LocationInverter, ParentIsPreset, RelayChainAsNative,
+    AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
+    FungiblesAdapter, LocationInverter, ParentIsPreset, RelayChainAsNative,
     SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
     SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 };
@@ -100,7 +99,8 @@ pub use parachains_common::*;
 
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
 pub use subbridge_pallets::{
-    chainbridge, fungible_adapter::XTransferAdapter, helper, xcmbridge, xtransfer,
+    chainbridge, dynamic_trader::DynamicWeightTrader, fungible_adapter::XTransferAdapter, helper,
+    xcmbridge, xtransfer,
 };
 
 #[cfg(any(feature = "std", test))]
@@ -884,64 +884,8 @@ pub type FungiblesTransactor = FungiblesAdapter<
 >;
 
 parameter_types! {
-    pub KSMAssetId: AssetId = MultiLocation::new(1, Here).into();
-    pub PHAAssetId: AssetId = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into()))).into();
-    pub LocalPHAAssetId: AssetId = MultiLocation::new(0, Here).into();
-    pub KARAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::karura::ID), GeneralKey(parachains::karura::KAR_KEY.to_vec()))).into();
-    pub KUSDAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::karura::ID), GeneralKey(parachains::karura::KUSD_KEY.to_vec()))).into();
-    pub BNCAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::BNC_KEY.to_vec()))).into();
-    pub VSKSMAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::VSKSM_KEY.to_vec()))).into();
-    pub ZLKAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::bifrost::ID), GeneralKey(parachains::bifrost::ZLK_KEY.to_vec()))).into();
-    pub MOVRAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::moonbase::ID), PalletInstance(parachains::moonbase::DEV_INSTANCE))).into();
-    pub HKOAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::heiko::ID), GeneralKey(parachains::heiko::HKO_KEY.to_vec()))).into();
-    pub BSXAssetId: AssetId = MultiLocation::new(1, X2(Parachain(parachains::basilisk::ID), GeneralKey(parachains::basilisk::BSX_KEY.to_vec()))).into();
-
-    pub ExecutionPriceInKSM: (AssetId, u128) = (
-        KSMAssetId::get(),
-        pha_per_second() / 600
-    );
-    pub ExecutionPriceInPHA: (AssetId, u128) = (
-        PHAAssetId::get(),
-        pha_per_second()
-    );
-    pub ExecutionPriceInLocalPHA: (AssetId, u128) = (
-        LocalPHAAssetId::get(),
-        pha_per_second()
-    );
-    pub ExecutionPriceInKAR: (AssetId, u128) = (
-        KARAssetId::get(),
-        pha_per_second() / 8
-    );
-    pub ExecutionPriceInKUSD: (AssetId, u128) = (
-        KUSDAssetId::get(),
-        pha_per_second() / 4
-    );
-    pub ExecutionPriceInBNC: (AssetId, u128) = (
-        BNCAssetId::get(),
-        pha_per_second() / 4
-    );
-    pub ExecutionPriceInVSKSM: (AssetId, u128) = (
-        VSKSMAssetId::get(),
-        pha_per_second() / 600
-    );
-    pub ExecutionPriceInZLK: (AssetId, u128) = (
-        ZLKAssetId::get(),
-        pha_per_second() / 4
-    );
-    pub ExecutionPriceInMOVR: (AssetId, u128) = (
-        MOVRAssetId::get(),
-        pha_per_second() / 240
-    );
-    pub ExecutionPriceInHKO: (AssetId, u128) = (
-        HKOAssetId::get(),
-        pha_per_second()
-    );
-    pub ExecutionPriceInBSX: (AssetId, u128) = (
-        BSXAssetId::get(),
-        pha_per_second()
-    );
-
     pub NativeExecutionPrice: u128 = pha_per_second();
+    pub WeightPerSecond: u64 = WEIGHT_PER_SECOND;
 }
 
 pub struct XcmConfig;
@@ -961,48 +905,12 @@ impl Config for XcmConfig {
     type LocationInverter = LocationInverter<Ancestry>;
     type Barrier = Barrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-    type Trader = (
-        FixedRateOfFungible<
-            ExecutionPriceInKSM,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInPHA,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInLocalPHA,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInKAR,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInBNC,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInVSKSM,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInZLK,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInHKO,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInMOVR,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-        FixedRateOfFungible<
-            ExecutionPriceInBSX,
-            helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
-        >,
-    );
+    type Trader = DynamicWeightTrader<
+        WeightPerSecond,
+        <Runtime as pallet_assets::Config>::AssetId,
+        AssetsRegistry,
+        helper::XTransferTakeRevenue<Self::AssetTransactor, AccountId, RhalaTreasuryAccount>,
+    >;
     type ResponseHandler = PolkadotXcm;
     type AssetTrap = PolkadotXcm;
     type AssetClaims = PolkadotXcm;

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -938,38 +938,6 @@ parameter_types! {
     );
 
     pub NativeExecutionPrice: u128 = pha_per_second();
-    pub ExecutionPrices: Vec<(AssetId, u128)> = [
-        ExecutionPriceInKSM::get(),
-        ExecutionPriceInPHA::get(),
-        ExecutionPriceInLocalPHA::get(),
-        ExecutionPriceInKAR::get(),
-        ExecutionPriceInKUSD::get(),
-        ExecutionPriceInBNC::get(),
-        ExecutionPriceInVSKSM::get(),
-        ExecutionPriceInZLK::get(),
-        ExecutionPriceInMOVR::get(),
-        ExecutionPriceInHKO::get(),
-        ExecutionPriceInBSX::get(),
-    ].to_vec().into();
-
-    pub FeeAssets: MultiAssets = [
-        KSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        PHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        LocalPHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        KARAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        KUSDAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        BNCAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        VSKSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        ZLKAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        MOVRAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        HKOAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        BSXAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-    ].to_vec().into();
-
-    // This fee is set when we trying to send assets that dest chain not support
-    // it as trade fee, thus we set PHA as the fee asset, and give this default
-    // amount to pay fee.
-    pub const DefaultDestChainXcmFee: Balance = 10 * CENTS;
 }
 
 pub struct XcmConfig;
@@ -1088,19 +1056,17 @@ impl pallet_xcm::Config for Runtime {
     type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl xcmbridge::Config for Runtime {
-    type Event = Event;
-    type Currency = Balances;
-    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmRouter = XcmRouter;
-    type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-    type LocationInverter = LocationInverter<Ancestry>;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-    type FeeAssets = FeeAssets;
-    type DefaultFee = DefaultDestChainXcmFee;
-    type AssetsRegistry = AssetsRegistry;
+impl xcm_transfer::Config for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+	type AssetsRegistry = AssetsRegistry;
 }
 
 impl assets_registry::Config for Runtime {
@@ -1423,16 +1389,15 @@ impl chainbridge::Config for Runtime {
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
     type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-    type NativeExecutionPrice = NativeExecutionPrice;
-    type ExecutionPriceInfo = ExecutionPrices;
-    type TreasuryAccount = RhalaTreasuryAccount;
-    type FungibleAdapter = XTransferAdapter<
-        CurrencyTransactor,
-        FungiblesTransactor,
-        XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
-    >;
-    type AssetsRegistry = AssetsRegistry;
+	type NativeExecutionPrice = NativeExecutionPrice;
+	type TreasuryAccount = RhalaTreasuryAccount;
+	type FungibleAdapter = XTransferAdapter<
+		CurrencyTransactor,
+		FungiblesTransactor,
+		XTransfer,
+		helper::NativeAssetFilter<ParachainInfo>,
+	>;
+	type AssetsRegistry = AssetsRegistry;
 }
 
 impl xtransfer::Config for Runtime {

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1057,16 +1057,16 @@ impl pallet_xcm::Config for Runtime {
 }
 
 impl xcm_transfer::Config for Runtime {
-	type Event = Event;
-	type Currency = Balances;
-	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmRouter = XcmRouter;
-	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type LocationInverter = LocationInverter<Ancestry>;
-	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type AssetsRegistry = AssetsRegistry;
+    type Event = Event;
+    type Currency = Balances;
+    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    type XcmRouter = XcmRouter;
+    type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    type XcmExecutor = XcmExecutor<XcmConfig>;
+    type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+    type LocationInverter = LocationInverter<Ancestry>;
+    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type AssetsRegistry = AssetsRegistry;
 }
 
 impl assets_registry::Config for Runtime {
@@ -1389,15 +1389,15 @@ impl chainbridge::Config for Runtime {
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
     type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type NativeExecutionPrice = NativeExecutionPrice;
-	type TreasuryAccount = RhalaTreasuryAccount;
-	type FungibleAdapter = XTransferAdapter<
-		CurrencyTransactor,
-		FungiblesTransactor,
-		XTransfer,
-		helper::NativeAssetFilter<ParachainInfo>,
-	>;
-	type AssetsRegistry = AssetsRegistry;
+    type NativeExecutionPrice = NativeExecutionPrice;
+    type TreasuryAccount = RhalaTreasuryAccount;
+    type FungibleAdapter = XTransferAdapter<
+        CurrencyTransactor,
+        FungiblesTransactor,
+        XTransfer,
+        helper::NativeAssetFilter<ParachainInfo>,
+    >;
+    type AssetsRegistry = AssetsRegistry;
 }
 
 impl xtransfer::Config for Runtime {

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1108,6 +1108,7 @@ impl assets_registry::Config for Runtime {
     type RegistryCommitteeOrigin = EnsureRootOrHalfCouncil;
     type Currency = Balances;
     type MinBalance = ExistentialDeposit;
+    type NativeExecutionPrice = NativeExecutionPrice;
 }
 
 parameter_types! {

--- a/runtime/rhala/src/migrations.rs
+++ b/runtime/rhala/src/migrations.rs
@@ -3,22 +3,6 @@ use super::*;
 #[allow(unused_imports)]
 use frame_support::traits::OnRuntimeUpgrade;
 
-// Note to "late-migration":
-//
-// All the migrations defined in this file are so called "late-migration". We should have done the
-// pallet migrations as soon as we perform the runtime upgrade. However the runtime v1090 was done
-// without applying the necessary migrations. Without the migrations, affected pallets can no
-// longer access the state db properly.
-//
-// So here we need to redo the migrations afterward. An immediate problem is that, after the new
-// pallets are upgraded, they may have already written some data under the new pallet storage
-// prefixes. Most of the pre_upgrade logic checks there's no data under the new pallets as a safe
-// guard. However for "late-migrations" this is not the case.
-//
-// The final decision is to just skip the pre_upgrade checks. We have carefully checked all the
-// pre_upgrade checks and confirmed that only the prefix checks are skipped. All the other checks
-// are still performed in an offline try-runtime test.
-
 pub struct SubbridgeV3Migrations;
 
 impl OnRuntimeUpgrade for SubbridgeV3Migrations {

--- a/runtime/rhala/src/migrations.rs
+++ b/runtime/rhala/src/migrations.rs
@@ -2,3 +2,55 @@
 use super::*;
 #[allow(unused_imports)]
 use frame_support::traits::OnRuntimeUpgrade;
+
+// Note to "late-migration":
+//
+// All the migrations defined in this file are so called "late-migration". We should have done the
+// pallet migrations as soon as we perform the runtime upgrade. However the runtime v1090 was done
+// without applying the necessary migrations. Without the migrations, affected pallets can no
+// longer access the state db properly.
+//
+// So here we need to redo the migrations afterward. An immediate problem is that, after the new
+// pallets are upgraded, they may have already written some data under the new pallet storage
+// prefixes. Most of the pre_upgrade logic checks there's no data under the new pallets as a safe
+// guard. However for "late-migrations" this is not the case.
+//
+// The final decision is to just skip the pre_upgrade checks. We have carefully checked all the
+// pre_upgrade checks and confirmed that only the prefix checks are skipped. All the other checks
+// are still performed in an offline try-runtime test.
+
+pub struct SubbridgeV3Migrations;
+
+impl OnRuntimeUpgrade for SubbridgeV3Migrations {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        subbridge_pallets::migration::subbridge_v3_migration::migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<(), &'static str> {
+        subbridge_pallets::migration::subbridge_v3_migration::pre_migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade() -> Result<(), &'static str> {
+        subbridge_pallets::migration::subbridge_v3_migration::post_migrate::<Runtime>()
+    }
+}
+
+pub struct AssetsRegistryV2Migrations;
+
+impl OnRuntimeUpgrade for AssetsRegistryV2Migrations {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        assets_registry::migration::assets_registry_v3_migration_for_rhala::migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<(), &'static str> {
+        assets_registry::migration::assets_registry_v3_migration_for_rhala::pre_migrate::<Runtime>()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade() -> Result<(), &'static str> {
+        assets_registry::migration::assets_registry_v3_migration_for_rhala::post_migrate::<Runtime>()
+    }
+}

--- a/runtime/rhala/src/migrations.rs
+++ b/runtime/rhala/src/migrations.rs
@@ -23,17 +23,17 @@ pub struct SubbridgeV3Migrations;
 
 impl OnRuntimeUpgrade for SubbridgeV3Migrations {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        subbridge_pallets::migration::subbridge_v3_migration::migrate::<Runtime>()
+        subbridge_pallets::migration::subbridge_v3_migration_for_rhala::migrate::<Runtime>()
     }
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<(), &'static str> {
-        subbridge_pallets::migration::subbridge_v3_migration::pre_migrate::<Runtime>()
+        subbridge_pallets::migration::subbridge_v3_migration_for_rhala::pre_migrate::<Runtime>()
     }
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        subbridge_pallets::migration::subbridge_v3_migration::post_migrate::<Runtime>()
+        subbridge_pallets::migration::subbridge_v3_migration_for_rhala::post_migrate::<Runtime>()
     }
 }
 

--- a/runtime/rhala/src/migrations.rs
+++ b/runtime/rhala/src/migrations.rs
@@ -51,6 +51,7 @@ impl OnRuntimeUpgrade for AssetsRegistryV2Migrations {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade() -> Result<(), &'static str> {
-        assets_registry::migration::assets_registry_v3_migration_for_rhala::post_migrate::<Runtime>()
+        assets_registry::migration::assets_registry_v3_migration_for_rhala::post_migrate::<Runtime>(
+        )
     }
 }

--- a/runtime/thala/src/constants.rs
+++ b/runtime/thala/src/constants.rs
@@ -78,33 +78,3 @@ pub mod fee {
         base_tx_fee * tx_per_second
     }
 }
-
-pub mod parachains {
-    pub mod karura {
-        pub const ID: u32 = 2000;
-        pub const KAR_KEY: [u8; 2] = [0, 128];
-        pub const KUSD_KEY: [u8; 2] = [0, 129];
-    }
-
-    pub mod bifrost {
-        pub const ID: u32 = 2001;
-        pub const BNC_KEY: &[u8] = &[0, 1];
-        pub const VSKSM_KEY: &[u8] = &[4, 4];
-        pub const ZLK_KEY: &[u8] = &[2, 7];
-    }
-
-    pub mod moonbase {
-        pub const ID: u32 = 1000;
-        pub const DEV_INSTANCE: u8 = 3;
-    }
-
-    pub mod heiko {
-        pub const ID: u32 = 2085;
-        pub const HKO_KEY: &[u8] = &[72, 75, 79]; // "HKO"
-    }
-
-    pub mod basilisk {
-        pub const ID: u32 = 2090;
-        pub const BSX_KEY: &[u8] = &[0, 0, 0, 0];
-    }
-}

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -189,6 +189,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    (),
 >;
 
 type EnsureRootOrHalfCouncil = EnsureOneOf<
@@ -859,7 +860,7 @@ pub type CurrencyTransactor = CurrencyAdapter<
     // Use this currency:
     Balances,
     // Use this currency when it is a fungible asset matching the given location or name:
-    helper::NativeAssetMatcher<helper::NativeAssetFilter<ParachainInfo>>,
+    helper::NativeAssetMatcher<assets_registry::NativeAssetFilter<ParachainInfo>>,
     // Convert an XCM MultiLocation into a local account id:
     LocationToAccountId,
     // Our chain's account ID type (we can't get away without mentioning it explicitly):
@@ -965,7 +966,7 @@ impl Config for XcmConfig {
         CurrencyTransactor,
         FungiblesTransactor,
         XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
+        assets_registry::NativeAssetFilter<ParachainInfo>,
     >;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = helper::AssetOriginFilter;
@@ -1085,7 +1086,7 @@ impl xcmbridge::Config for Runtime {
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
     type LocationInverter = LocationInverter<Ancestry>;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
     type AssetsRegistry = AssetsRegistry;
 }
 
@@ -1095,6 +1096,7 @@ impl assets_registry::Config for Runtime {
     type Currency = Balances;
     type MinBalance = ExistentialDeposit;
     type NativeExecutionPrice = NativeExecutionPrice;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
 }
 
 parameter_types! {
@@ -1408,14 +1410,14 @@ impl chainbridge::Config for Runtime {
     type BridgeChainId = BridgeChainId;
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type NativeAssetChecker = assets_registry::NativeAssetFilter<ParachainInfo>;
     type NativeExecutionPrice = NativeExecutionPrice;
     type TreasuryAccount = KhalaTreasuryAccount;
     type FungibleAdapter = XTransferAdapter<
         CurrencyTransactor,
         FungiblesTransactor,
         XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
+        assets_registry::NativeAssetFilter<ParachainInfo>,
     >;
     type AssetsRegistry = AssetsRegistry;
 }

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1128,6 +1128,7 @@ impl assets_registry::Config for Runtime {
     type RegistryCommitteeOrigin = EnsureRootOrHalfCouncil;
     type Currency = Balances;
     type MinBalance = ExistentialDeposit;
+    type NativeExecutionPrice = NativeExecutionPrice;
 }
 
 parameter_types! {

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1076,7 +1076,7 @@ impl pallet_xcm::Config for Runtime {
     type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl xcm_transfer::Config for Runtime {
+impl xcmbridge::Config for Runtime {
     type Event = Event;
     type Currency = Balances;
     type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1077,16 +1077,16 @@ impl pallet_xcm::Config for Runtime {
 }
 
 impl xcm_transfer::Config for Runtime {
-	type Event = Event;
-	type Currency = Balances;
-	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmRouter = XcmRouter;
-	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-	type LocationInverter = LocationInverter<Ancestry>;
-	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type AssetsRegistry = AssetsRegistry;
+    type Event = Event;
+    type Currency = Balances;
+    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    type XcmRouter = XcmRouter;
+    type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    type XcmExecutor = XcmExecutor<XcmConfig>;
+    type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+    type LocationInverter = LocationInverter<Ancestry>;
+    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+    type AssetsRegistry = AssetsRegistry;
 }
 
 impl assets_registry::Config for Runtime {
@@ -1409,15 +1409,15 @@ impl chainbridge::Config for Runtime {
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
     type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-	type NativeExecutionPrice = NativeExecutionPrice;
-	type TreasuryAccount = KhalaTreasuryAccount;
-	type FungibleAdapter = XTransferAdapter<
-		CurrencyTransactor,
-		FungiblesTransactor,
-		XTransfer,
-		helper::NativeAssetFilter<ParachainInfo>,
-	>;
-	type AssetsRegistry = AssetsRegistry;
+    type NativeExecutionPrice = NativeExecutionPrice;
+    type TreasuryAccount = KhalaTreasuryAccount;
+    type FungibleAdapter = XTransferAdapter<
+        CurrencyTransactor,
+        FungiblesTransactor,
+        XTransfer,
+        helper::NativeAssetFilter<ParachainInfo>,
+    >;
+    type AssetsRegistry = AssetsRegistry;
 }
 
 impl xtransfer::Config for Runtime {

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -954,38 +954,6 @@ parameter_types! {
     );
 
     pub NativeExecutionPrice: u128 = pha_per_second();
-    pub ExecutionPrices: Vec<(AssetId, u128)> = [
-        ExecutionPriceInKSM::get(),
-        ExecutionPriceInPHA::get(),
-        ExecutionPriceInLocalPHA::get(),
-        ExecutionPriceInKAR::get(),
-        ExecutionPriceInKUSD::get(),
-        ExecutionPriceInBNC::get(),
-        ExecutionPriceInVSKSM::get(),
-        ExecutionPriceInZLK::get(),
-        ExecutionPriceInMOVR::get(),
-        ExecutionPriceInHKO::get(),
-        ExecutionPriceInBSX::get(),
-    ].to_vec().into();
-
-    pub FeeAssets: MultiAssets = [
-        KSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        PHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        LocalPHAAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        KARAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        KUSDAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        BNCAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        VSKSMAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        ZLKAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        MOVRAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        HKOAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-        BSXAssetId::get().into_multiasset(Fungibility::Fungible(u128::MAX)),
-    ].to_vec().into();
-
-    // This fee is set when we trying to send assets that dest chain not support
-    // it as trade fee, thus we set PHA as the fee asset, and give this default
-    // amount to pay fee.
-    pub const DefaultDestChainXcmFee: Balance = 10 * CENTS;
 }
 
 pub struct XcmConfig;
@@ -1108,19 +1076,17 @@ impl pallet_xcm::Config for Runtime {
     type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
 }
 
-impl xcmbridge::Config for Runtime {
-    type Event = Event;
-    type Currency = Balances;
-    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmRouter = XcmRouter;
-    type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
-    type LocationInverter = LocationInverter<Ancestry>;
-    type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-    type FeeAssets = FeeAssets;
-    type DefaultFee = DefaultDestChainXcmFee;
-    type AssetsRegistry = AssetsRegistry;
+impl xcm_transfer::Config for Runtime {
+	type Event = Event;
+	type Currency = Balances;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmRouter = XcmRouter;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type XcmExecutor = XcmExecutor<XcmConfig>;
+	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	type LocationInverter = LocationInverter<Ancestry>;
+	type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
+	type AssetsRegistry = AssetsRegistry;
 }
 
 impl assets_registry::Config for Runtime {
@@ -1443,16 +1409,15 @@ impl chainbridge::Config for Runtime {
     type Currency = Balances;
     type ProposalLifetime = ProposalLifetime;
     type NativeAssetChecker = helper::NativeAssetFilter<ParachainInfo>;
-    type NativeExecutionPrice = NativeExecutionPrice;
-    type ExecutionPriceInfo = ExecutionPrices;
-    type TreasuryAccount = KhalaTreasuryAccount;
-    type FungibleAdapter = XTransferAdapter<
-        CurrencyTransactor,
-        FungiblesTransactor,
-        XTransfer,
-        helper::NativeAssetFilter<ParachainInfo>,
-    >;
-    type AssetsRegistry = AssetsRegistry;
+	type NativeExecutionPrice = NativeExecutionPrice;
+	type TreasuryAccount = KhalaTreasuryAccount;
+	type FungibleAdapter = XTransferAdapter<
+		CurrencyTransactor,
+		FungiblesTransactor,
+		XTransfer,
+		helper::NativeAssetFilter<ParachainInfo>,
+	>;
+	type AssetsRegistry = AssetsRegistry;
 }
 
 impl xtransfer::Config for Runtime {

--- a/scripts/try-runtime.sh
+++ b/scripts/try-runtime.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Rhala
+# ./target/release/khala-node try-runtime --chain rhala-staging-2004 on-runtime-upgrade live -u "wss://rhala-api.phala.network:443/ws" --at 0xf83a6f466ac30169274e90ad3989f9e95252f24c1c19f0a3f63476430902c333
+
+# Khala
+./target/release/khala-node try-runtime --chain khala-staging-2004 on-runtime-upgrade live -u "wss://khala-rpc.dwellir.com:443" --at 0x333d2efc5ac202a2eeec4bd5e0a092ae7a6d30db3eec2ad439a1fe99bc3dfd70


### PR DESCRIPTION
The origin [PR](https://github.com/Phala-Network/khala-parachain/pull/92) to implement dynamic trader is not compatible with the new SubBridge code, so I picked those stuff to a new PR.

With the dynamic trader introduced, an execution price would be given when registering a new asset. The execution price indicates how much that asset needs to pay per second on our network when buying the resource, which has the same meaning as the returned value of [pha_per_second()](https://github.com/Phala-Network/khala-parachain/blob/12d76b52cf90084a742618aee36b95893327b06a/runtime/khala/src/constants.rs#L73).

This PR would contain storage migration on pallet `chainbridge` and pallet `assets-registry`. They are:
- Remove the fee scale from `chainbridge::BridgeFee`, every ChainBridge only has a constant min fee set.
- Add `execution_price` into asset registry info, which would be used to calculate fee when sending a crosschain transfer of that asset