### PR TITLE
Integrate Phala World Pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3834,6 +3834,7 @@ dependencies = [
  "pallet-mq-runtime-api",
  "pallet-multisig",
  "pallet-parachain-info",
+ "pallet-phala-world",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
@@ -3857,6 +3858,7 @@ dependencies = [
  "phala-types",
  "polkadot-parachain",
  "polkadot-runtime-common",
+ "rmrk-traits",
  "scale-info",
  "serde",
  "smallvec",
@@ -5969,6 +5971,29 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+]
+
+[[package]]
+name = "pallet-phala-world"
+version = "0.1.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-rmrk-core",
+ "pallet-rmrk-equip",
+ "pallet-rmrk-market",
+ "pallet-timestamp",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -8716,6 +8741,7 @@ dependencies = [
  "pallet-mq-runtime-api",
  "pallet-multisig",
  "pallet-parachain-info",
+ "pallet-phala-world",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
@@ -8740,6 +8766,7 @@ dependencies = [
  "phala-types",
  "polkadot-parachain",
  "polkadot-runtime-common",
+ "rmrk-traits",
  "scale-info",
  "smallvec",
  "sp-api",
@@ -8794,6 +8821,7 @@ name = "rmrk-traits"
 version = "0.0.1"
 source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-balances",
@@ -11675,6 +11703,7 @@ dependencies = [
  "pallet-mq-runtime-api",
  "pallet-multisig",
  "pallet-parachain-info",
+ "pallet-phala-world",
  "pallet-preimage",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
@@ -11699,6 +11728,7 @@ dependencies = [
  "phala-types",
  "polkadot-parachain",
  "polkadot-runtime-common",
+ "rmrk-traits",
  "scale-info",
  "smallvec",
  "sp-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
+ "pallet-uniques",
  "pallet-utility 4.0.0-phala-dev",
  "pallet-vesting",
  "pallet-xcm",
@@ -6253,6 +6254,7 @@ name = "pallet-uniques"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.22#616d33ea23bab86cafffaf116fc607b6790fb4eb"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
@@ -8666,6 +8668,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
+ "pallet-uniques",
  "pallet-utility 4.0.0-phala-dev",
  "pallet-vesting",
  "pallet-xcm",
@@ -11606,6 +11609,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury",
+ "pallet-uniques",
  "pallet-utility 4.0.0-phala-dev",
  "pallet-vesting",
  "pallet-xcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,9 @@ dependencies = [
  "pallet-preimage",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
+ "pallet-rmrk-core",
+ "pallet-rmrk-equip",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-session",
  "pallet-timestamp",
@@ -6024,6 +6027,62 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-rmrk-core"
+version = "0.0.1"
+source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-rmrk-equip"
+version = "0.0.1"
+source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-rmrk-core",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-rmrk-market"
+version = "0.0.1"
+source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-rmrk-core",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "rmrk-traits",
+ "scale-info",
+ "serde",
  "sp-runtime",
  "sp-std",
 ]
@@ -8660,6 +8719,9 @@ dependencies = [
  "pallet-preimage",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
+ "pallet-rmrk-core",
+ "pallet-rmrk-equip",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
@@ -8725,6 +8787,21 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rmrk-traits"
+version = "0.0.1"
+source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -11601,6 +11678,9 @@ dependencies = [
  "pallet-preimage",
  "pallet-proxy",
  "pallet-randomness-collective-flip",
+ "pallet-rmrk-core",
+ "pallet-rmrk-equip",
+ "pallet-rmrk-market",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
 	"pallets/phala/mq-runtime-api",
 	"pallets/subbridge",
 	"pallets/parachain-info",
+	"pallets/phala-world",
 	"runtime/phala",
 	"runtime/khala",
 	"runtime/rhala",

--- a/pallets/phala-world/Cargo.toml
+++ b/pallets/phala-world/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "pallet-phala-world"
+version = "0.1.0"
+description = "Phala World"
+authors = ["Phala Network"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://phala.network/"
+repository = "https://github.com/Phala-Network/phala-blockchain"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+serde = { version = "1.0.111", default-features = false, features = ["derive"] }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
+	"derive",
+] }
+sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22"}
+frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22", optional = true }
+
+pallet-uniques = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+pallet-balances = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+pallet-timestamp = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+
+# RMRK dependencies
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+
+[dev-dependencies]
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
+
+[features]
+default = ["std"]
+std = [
+	"pallet-uniques/std",
+	"pallet-balances/std",
+	"pallet-timestamp/std",
+	"pallet-rmrk-core/std",
+	"pallet-rmrk-equip/std",
+	"pallet-rmrk-market/std",
+	"rmrk-traits/std",
+	"serde/std",
+	"codec/std",
+	"scale-info/std",
+	"frame-support/std",
+	"frame-system/std",
+	"frame-benchmarking/std",
+	"sp-io/std",
+	"sp-core/std",
+]
+
+runtime-benchmarks = ["frame-benchmarking/runtime-benchmarks"]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/phala-world/README.md
+++ b/pallets/phala-world/README.md
@@ -1,0 +1,267 @@
+# Phala World
+
+## Types
+```rust
+pub enum OriginOfShellType {
+    /// Origin of Shell type is Prime
+    Prime,
+    /// Origin of Shell type is Magic
+    Magic,
+    /// Origin of Shell is Legendary
+    Legendary,
+}
+
+/// Four Races to choose from
+#[derive(Encode, Decode, Clone, PartialEq)]
+pub enum RaceType {
+    Cyborg,
+    AISpectre,
+    XGene,
+    Pandroid,
+}
+
+/// Five Careers to choose from
+#[derive(Encode, Decode, Clone, PartialEq)]
+pub enum CareerType {
+    HardwareDruid,
+    RoboWarrior,
+    TradeNegotiator,
+    HackerWizard,
+    Web3Monk,
+}
+```
+
+### Constants
+```rust
+/// Seconds per Era that will increment the Era storage value every interval
+#[pallet::constant]
+type SecondsPerEra: Get<u64>;
+/// Price of Legendary Origin of Shell
+#[pallet::constant]
+type LegendaryOriginOfShellPrice: Get<BalanceOf<Self>>;
+/// Price of Magic Origin of Shell
+#[pallet::constant]
+type MagicOriginOfShellPrice: Get<BalanceOf<Self>>;
+/// Price of Prime Origin of Shell
+#[pallet::constant]
+type PrimeOriginOfShellPrice: Get<BalanceOf<Self>>;
+/// Max mint per Race
+#[pallet::constant]
+type MaxMintPerRace: Get<u32>;
+/// Max mint per Career
+#[pallet::constant]
+type MaxMintPerCareer: Get<u32>;
+/// Amount of food per Era
+#[pallet::constant]
+type FoodPerEra: Get<u32>;
+/// Max food to feed your own Origin Of Shell
+#[pallet::constant]
+type MaxFoodFeedSelf: Get<u8>;
+```
+
+## Storage
+```rust
+/// Stores all of the valid claimed spirits from the airdrop by serial id & bool true if claimed
+#[pallet::storage]
+#[pallet::getter(fn claimed_spirits)]
+pub type ClaimedSpirits<T: Config> = StorageMap<_, Twox64Concat, SerialId, bool>;
+
+/// Preorder index that is the key to the Preorders StorageMap
+#[pallet::storage]
+#[pallet::getter(fn preorder_index)]
+pub type PreorderIndex<T: Config> = StorageValue<_, PreorderId, ValueQuery>;
+
+/// Preorder info map for user preorders
+#[pallet::storage]
+#[pallet::getter(fn preorders)]
+pub type Preorders<T: Config> = StorageMap<_, Twox64Concat, PreorderId, PreorderInfoOf<T>>;
+
+/// Food per Owner where an owner gets 5 food per era
+#[pallet::storage]
+#[pallet::getter(fn get_food_by_owner)]
+pub type FoodByOwners<T: Config> = StorageMap<_, Twox64Concat, T::AccountId, u8>;
+
+/// Phala World Zero Day `BlockNumber` this will be used to determine Eras
+#[pallet::storage]
+#[pallet::getter(fn zero_day)]
+pub(super) type ZeroDay<T: Config> = StorageValue<_, u64>;
+
+/// The current Era from the initial ZeroDay BlockNumber
+#[pallet::storage]
+#[pallet::getter(fn era)]
+pub type Era<T: Config> = StorageValue<_, EraId, ValueQuery>;
+
+/// Spirits can be claimed
+#[pallet::storage]
+#[pallet::getter(fn can_claim_spirits)]
+pub type CanClaimSpirits<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+/// Rare Origin of Shells can be purchased
+#[pallet::storage]
+#[pallet::getter(fn can_purchase_rare_origin_of_shells)]
+pub type CanPurchaseRareOriginOfShells<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+/// Origin of Shells can be preordered
+#[pallet::storage]
+#[pallet::getter(fn can_preorder_origin_of_shells)]
+pub type CanPreorderOriginOfShells<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+/// Race Type count
+#[pallet::storage]
+#[pallet::getter(fn race_type_count)]
+pub type RaceTypeLeft<T: Config> = StorageMap<_, Twox64Concat, RaceType, u32, ValueQuery>;
+
+/// Race StorageMap count
+#[pallet::storage]
+#[pallet::getter(fn career_type_count)]
+pub type CareerTypeLeft<T: Config> = StorageMap<_, Twox64Concat, CareerType, u32, ValueQuery>;
+
+/// Overlord Admin account of Phala World
+#[pallet::storage]
+#[pallet::getter(fn overlord)]
+pub(super) type Overlord<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
+/// Spirit Collection ID
+#[pallet::storage]
+#[pallet::getter(fn spirit_collection_id)]
+pub type SpiritCollectionId<T: Config> = StorageValue<_, CollectionId, OptionQuery>;
+
+/// Origin of Shell Collection ID
+#[pallet::storage]
+#[pallet::getter(fn origin_of_shell_collection_id)]
+pub type OriginOfShellCollectionId<T: Config> = StorageValue<_, CollectionId, OptionQuery>;
+```
+
+## Errors
+```rust
+/// Errors displayed to inform users something went wrong
+#[pallet::error]
+pub enum Error<T> {
+    WorldClockAlreadySet,
+    SpiritClaimNotAvailable,
+    RareOriginOfShellPurchaseNotAvailable,
+    PreorderOriginOfShellNotAvailable,
+    SpiritAlreadyClaimed,
+    ClaimVerificationFailed,
+    InvalidPurchase,
+    NoAvailablePreorderId,
+    RaceMintMaxReached,
+    CareerMintMaxReached,
+    CannotHatchOriginOfShell,
+    CannotSendFoodToOriginOfShell,
+    NoFoodAvailable,
+    OverlordNotSet,
+    RequireOverlordAccount,
+    InvalidStatusType,
+    SpiritCollectionNotSet,
+    SpiritCollectionIdAlreadySet,
+    OriginOfShellCollectionNotSet,
+    OriginOfShellCollectionIdAlreadySet,
+}
+```
+
+## Calls
+### claim_spirit
+Claim a spirit for users that have at least 10 PHA in account
+```rust
+origin: OriginFor<T>,
+```
+
+### redeem_spirit
+Redeem a spirit for users that have a valid signed signature
+```rust
+origin: OriginFor<T>,
+signature: sr25519::Signature,
+```
+
+### buy_rare_origin_of_shell
+Buy a rare origin of shell of either type Magic or Legendary.
+```rust
+origin: OriginFor<T>,
+origin_of_shell_type: OriginOfShellType,
+race: RaceType,
+career: CareerType,
+```
+
+### purchase_prime_origin_of_shell
+```rust
+origin: OriginFor<T>,
+signature: sr25519::Signature,
+race: RaceType,
+career: CareerType,
+```
+
+
+### preorder_origin_of_shell
+Preorder an OriginOfShell for eligible users
+```rust
+origin: OriginFor<T>,
+race: RaceType,
+career: CareerType,
+```
+
+### mint_origin_of_shells
+This is an admin only function that will be called to do a bulk minting of all preordered origin of shell
+```rust
+origin: OriginFor<T>
+```
+
+### feed_origin_of_shell
+Feed another origin of shell to the current origin of shell being incubated.
+```rust
+origin: OriginFor<T>,
+collection_id: CollectionId,
+nft_id: NftId,
+```
+
+### awaken_origin_of_shell
+Hatch the origin of shell that is currently being incubated.
+```rust
+origin: OriginFor<T>,
+collection_id: CollectionId,
+nft_id: NftId,
+```
+
+### update_incubation_time
+This is an admin function to update origin of shells incubation times based on being in the top 10 of fed origin of shells within that era
+```rust
+origin: OriginFor<T>,
+collection_id: CollectionId,
+nft_id: NftId,
+reduced_time: u64,
+```
+
+### set_overlord
+Privileged function set the Overlord Admin account of Phala World.
+```rust
+origin: OriginFor<T>,
+new_overlord: T::AccountId,
+```
+
+### initialize_world_clock
+Privileged function where Phala World Zero Day is set to begin the tracking of the official time starting at the current timestamp.
+```rust
+origin: OriginFor<T>,
+```
+
+### set_status_type
+Privileged function to set the status for one of the defined StatusTypes like ClaimSpirits, PurchaseRareOriginOfShells, or PreorderOriginOfShells
+```rust
+origin: OriginFor<T>,
+status: bool,
+status_type: StatusType,
+```
+
+### set_spirit_collection_id
+Privileged function to set the collection id for the Spirits collection
+```rust
+origin: OriginFor<T>,
+collection_id: CollectionId,
+```
+
+### set_origin_of_shell_collection_id
+Privileged function to set the collection id for the OriginOfShell collection
+```rust
+origin: OriginFor<T>,
+collection_id: CollectionId,
+```

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -334,7 +334,7 @@ pub mod pallet {
 			metadata: BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
 		) -> DispatchResult {
 			let sender = ensure_signed(origin.clone())?;
-			pallet_pw_nft_sale::pallet::Pallet::<T>::ensure_overlord(sender)?;
+			pallet_pw_nft_sale::pallet::Pallet::<T>::ensure_overlord(&sender)?;
 			// Check if Incubation Phase has started
 			ensure!(
 				CanStartIncubation::<T>::get(),
@@ -449,7 +449,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			// Ensure OverlordOrigin makes call
 			let sender = ensure_signed(origin)?;
-			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(sender)?;
+			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(&sender)?;
 			// Iterate through Origin of Shells
 			for ((collection_id, nft_id), reduced_time) in origin_of_shells {
 				// Ensure that the collection is an Origin of Shell Collection
@@ -486,7 +486,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// Ensure Overlord account is the sender
 			let sender = ensure_signed(origin)?;
-			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(sender)?;
+			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(&sender)?;
 			// Get official hatch time to set in storage
 			let start_time = T::Time::now().as_secs();
 			let incubation_duration = T::IncubationDurationSec::get();
@@ -517,7 +517,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// Ensure Overlord account makes call
 			let sender = ensure_signed(origin)?;
-			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(sender)?;
+			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(&sender)?;
 			// If Spirit Collection ID is greater than 0 then the collection ID was already set
 			ensure!(
 				ShellCollectionId::<T>::get().is_none(),

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -447,7 +447,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			origin_of_shells: Vec<((CollectionId, NftId), u64)>,
 		) -> DispatchResult {
-			// Ensure OverlordOrigin makes call
+			// Ensure GovernanceOrigin makes call
 			let sender = ensure_signed(origin)?;
 			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(&sender)?;
 			// Iterate through Origin of Shells

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -1,0 +1,603 @@
+//! Phala World Incubation Pallet
+
+pub use crate::pallet_pw_nft_sale;
+pub use crate::traits::{primitives::*, CareerType, FoodInfo, OriginOfShellType, RaceType};
+use codec::Decode;
+use frame_support::{
+	ensure,
+	pallet_prelude::Get,
+	traits::{
+		tokens::nonfungibles::{Inspect, InspectEnumerable},
+		UnixTime,
+	},
+	transactional, BoundedVec,
+};
+use frame_system::{ensure_signed, pallet_prelude::*};
+pub use pallet_rmrk_core::types::*;
+pub use pallet_rmrk_market;
+use rmrk_traits::{primitives::*, resource::ResourceInfo, AccountIdOrCollectionNftTuple};
+use sp_std::vec::Vec;
+
+pub type ResourceOf<T, R, P> = ResourceInfo<
+	BoundedVec<u8, R>,
+	BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
+	BoundedVec<PartId, P>,
+>;
+
+pub use self::pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+	use frame_system::Origin;
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config:
+		frame_system::Config + pallet_rmrk_core::Config + pallet_pw_nft_sale::Config
+	{
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		/// Amount of food per Era
+		#[pallet::constant]
+		type FoodPerEra: Get<u32>;
+		/// Max food to feed your own Origin of Shell
+		#[pallet::constant]
+		type MaxFoodFeedSelf: Get<u8>;
+		/// Duration of incubation process
+		#[pallet::constant]
+		type IncubationDurationSec: Get<u64>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::without_storage_info]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	/// Info on Origin of Shells that the Owner has fed
+	#[pallet::storage]
+	#[pallet::getter(fn food_by_owners)]
+	pub type FoodByOwners<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		T::AccountId,
+		FoodInfo<BoundedVec<(CollectionId, NftId), <T as Config>::FoodPerEra>>,
+	>;
+
+	/// Total food fed to an Origin of Shell per Era
+	#[pallet::storage]
+	#[pallet::getter(fn origin_of_shell_food_stats)]
+	pub type OriginOfShellFoodStats<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		(CollectionId, NftId),
+		Blake2_128Concat,
+		EraId,
+		u32,
+		ValueQuery,
+	>;
+
+	/// Official hatch time for all Origin of Shells
+	#[pallet::storage]
+	#[pallet::getter(fn official_hatch_time)]
+	pub type OfficialHatchTime<T: Config> = StorageValue<_, u64, ValueQuery>;
+
+	/// Expected hatch Timestamp for an Origin of Shell that started the incubation process
+	#[pallet::storage]
+	#[pallet::getter(fn hatch_times)]
+	pub type HatchTimes<T: Config> =
+		StorageDoubleMap<_, Blake2_128Concat, CollectionId, Blake2_128Concat, NftId, u64>;
+
+	/// A bool value to determine if accounts can start incubation of Origin of Shells
+	#[pallet::storage]
+	#[pallet::getter(fn can_start_incubation)]
+	pub type CanStartIncubation<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Collection ID of the Shell NFT
+	#[pallet::storage]
+	#[pallet::getter(fn shell_collection_id)]
+	pub type ShellCollectionId<T: Config> = StorageValue<_, CollectionId>;
+
+	// Pallets use events to inform users when important changes are made.
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// CanStartIncubation status changed and set official hatch time
+		CanStartIncubationStatusChanged {
+			status: bool,
+			start_time: u64,
+			official_hatch_time: u64,
+		},
+		/// Origin of Shell owner has initiated the incubation sequence
+		StartedIncubation {
+			collection_id: CollectionId,
+			nft_id: NftId,
+			owner: T::AccountId,
+			start_time: u64,
+			hatch_time: u64,
+		},
+		/// Origin of Shell received food from an account
+		OriginOfShellReceivedFood {
+			collection_id: CollectionId,
+			nft_id: NftId,
+			sender: T::AccountId,
+		},
+		/// A top 10 fed origin_of_shell of the era has updated their incubation time
+		HatchTimeUpdated {
+			collection_id: CollectionId,
+			nft_id: NftId,
+			old_hatch_time: u64,
+			new_hatch_time: u64,
+		},
+		/// Shell Collection ID is set
+		ShellCollectionIdSet { collection_id: CollectionId },
+		/// Shell has been awakened from an origin_of_shell being hatched and burned
+		ShellAwakened {
+			collection_id: CollectionId,
+			nft_id: NftId,
+			owner: T::AccountId,
+		},
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		StartIncubationNotAvailable,
+		HatchingInProgress,
+		CannotHatchOriginOfShell,
+		CannotSendFoodToOriginOfShell,
+		MaxFoodFedLimitReached,
+		AlreadySentFoodTwice,
+		NoFoodAvailable,
+		NotOwner,
+		WrongCollectionId,
+		NoHatchTimeDetected,
+		ShellCollectionIdAlreadySet,
+		ShellCollectionIdNotSet,
+		RaceNotDetected,
+		CareerNotDetected,
+		OriginOfShellTypeNotDetected,
+		FoodInfoUpdateError,
+	}
+
+	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
+	// These functions materialize as "extrinsics", which are often compared to transactions.
+	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
+	{
+		/// Once users have received their origin_of_shells and the start incubation event has been
+		/// triggered, they can start the incubation process and a timer will start for the
+		/// origin_of_shell to awaken at a designated time. Origin of Shells can reduce their time
+		/// by being in the top 10 of origin_of_shell's fed per era.
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic starting the incubation process
+		/// - collection_id: The collection id of the Origin of Shell RMRK NFT
+		/// - nft_id: The NFT id of the Origin of Shell RMRK NFT
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn start_incubation(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			nft_id: NftId,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+			// Check if IncubationPhase is enabled
+			ensure!(
+				CanStartIncubation::<T>::get(),
+				Error::<T>::StartIncubationNotAvailable
+			);
+			// Ensure that the collection is an Origin of Shell Collection
+			ensure!(
+				Self::is_origin_of_shell_collection_id(collection_id),
+				Error::<T>::WrongCollectionId
+			);
+			// Ensure sender is owner
+			ensure!(
+				Self::is_owner(&sender, collection_id, nft_id),
+				Error::<T>::NotOwner
+			);
+			// Ensure incubation process hasn't been started already
+			ensure!(
+				!HatchTimes::<T>::contains_key(collection_id, nft_id),
+				Error::<T>::HatchingInProgress
+			);
+			// Get time to start hatching process
+			let start_time = T::Time::now().as_secs();
+			let hatch_time = OfficialHatchTime::<T>::get();
+			// Update Hatch Time storage
+			HatchTimes::<T>::insert(collection_id, nft_id, hatch_time);
+
+			Self::deposit_event(Event::StartedIncubation {
+				owner: sender,
+				collection_id,
+				nft_id,
+				start_time,
+				hatch_time,
+			});
+
+			Ok(())
+		}
+
+		/// Feed another origin_of_shell to the current origin_of_shell being incubated. This will
+		/// reduce the time left to incubation if the origin_of_shell is in the top 10 of
+		/// origin_of_shells fed that era.
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic feeding the origin_of_shell
+		/// - collection_id: The collection id of the Origin of Shell RMRK NFT
+		/// - nft_id: The NFT id of the Origin of Shell RMRK NFT
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn feed_origin_of_shell(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			nft_id: NftId,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+			// Check if Incubation Phase has started
+			ensure!(
+				CanStartIncubation::<T>::get(),
+				Error::<T>::StartIncubationNotAvailable
+			);
+			// Ensure that the collection is an Origin of Shell Collection
+			ensure!(
+				Self::is_origin_of_shell_collection_id(collection_id),
+				Error::<T>::WrongCollectionId
+			);
+			// Ensure that Origin of Shell exists or is not past the hatch time
+			let hatch_time = Self::get_hatch_time(collection_id, nft_id)?;
+			ensure!(
+				!Self::can_hatch(hatch_time),
+				Error::<T>::CannotSendFoodToOriginOfShell
+			);
+			// Check if account owns an Origin of Shell NFT
+			ensure!(
+				pallet_uniques::pallet::Pallet::<T>::owned_in_class(&collection_id, &sender)
+					.count() > 0,
+				Error::<T>::CannotSendFoodToOriginOfShell
+			);
+			// Get Current Era
+			let current_era = pallet_pw_nft_sale::Era::<T>::get();
+			// Get number of times fed this era
+			let num_of_times_fed =
+				OriginOfShellFoodStats::<T>::get((collection_id, nft_id), current_era);
+
+			// Update account FoodInfo if not updated or create new FoodInfo for account's first
+			// feeding
+			FoodByOwners::<T>::try_mutate(&sender, |food_info| -> DispatchResult {
+				let mut new_food_info = match food_info {
+					None => Self::get_new_food_info(current_era),
+					Some(food_info) if current_era > food_info.era => {
+						Self::get_new_food_info(current_era)
+					}
+					Some(food_info) => {
+						// Ensure sender hasn't fed the Origin of Shell 2 times
+						ensure!(
+							food_info
+								.origin_of_shells_fed
+								.iter()
+								.filter(|&nft| *nft == (collection_id, nft_id))
+								.count() < T::MaxFoodFeedSelf::get().into(),
+							Error::<T>::AlreadySentFoodTwice
+						);
+						food_info.clone()
+					}
+				};
+				ensure!(
+					new_food_info
+						.origin_of_shells_fed
+						.try_push((collection_id, nft_id))
+						.is_ok(),
+					Error::<T>::FoodInfoUpdateError
+				);
+				*food_info = Some(new_food_info);
+
+				Ok(())
+			})?;
+
+			// Update the Origin of Shell food stats
+			OriginOfShellFoodStats::<T>::insert(
+				(collection_id, nft_id),
+				current_era,
+				num_of_times_fed + 1,
+			);
+
+			Self::deposit_event(Event::OriginOfShellReceivedFood {
+				collection_id,
+				nft_id,
+				sender,
+			});
+
+			Ok(())
+		}
+
+		/// Hatch the origin_of_shell that is currently being hatched. This will trigger the end of
+		/// the incubation process and the origin_of_shell will be burned. After burning, the user
+		/// will receive the awakened Shell RMRK NFT
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic incubation the origin_of_shell
+		/// - collection_id: The collection id of the Origin of Shell RMRK NFT
+		/// - nft_id: The NFT id of the Origin of Shell RMRK NFT
+		/// - metadata: File resource URI in decentralized storage
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn hatch_origin_of_shell(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+			nft_id: NftId,
+			metadata: BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+			pallet_pw_nft_sale::pallet::Pallet::<T>::ensure_overlord(sender)?;
+			// Check if Incubation Phase has started
+			ensure!(
+				CanStartIncubation::<T>::get(),
+				Error::<T>::StartIncubationNotAvailable
+			);
+			// Ensure that the collection is an Origin of Shell Collection
+			ensure!(
+				Self::is_origin_of_shell_collection_id(collection_id),
+				Error::<T>::WrongCollectionId
+			);
+			// Get owner of the Origin of Shell NFT
+			let (owner, _) =
+				pallet_rmrk_core::Pallet::<T>::lookup_root_owner(collection_id, nft_id)?;
+			// Check if HatchTimes is less than or equal to current Timestamp
+			// Ensure that Origin of Shell exists or is not past the hatch time
+			let hatch_time = Self::get_hatch_time(collection_id, nft_id)?;
+			ensure!(
+				Self::can_hatch(hatch_time),
+				Error::<T>::CannotHatchOriginOfShell
+			);
+			// Check if Shell Collection ID is set
+			let shell_collection_id = Self::get_shell_collection_id()?;
+			// Get race, key and origin of shell type before burning origin of shell NFT
+			let race_key = pallet_pw_nft_sale::pallet::Pallet::<T>::to_boundedvec_key("race")?;
+			let career_key = pallet_pw_nft_sale::pallet::Pallet::<T>::to_boundedvec_key("career")?;
+			let origin_of_shell_type_key =
+				pallet_pw_nft_sale::Pallet::<T>::to_boundedvec_key("origin_of_shell_type")?;
+			let race = pallet_uniques::Pallet::<T>::attribute(&collection_id, &nft_id, &race_key)
+				.ok_or(Error::<T>::RaceNotDetected)?;
+			let career =
+				pallet_uniques::Pallet::<T>::attribute(&collection_id, &nft_id, &career_key)
+					.ok_or(Error::<T>::CareerNotDetected)?;
+			let origin_of_shell_type_value = pallet_uniques::Pallet::<T>::attribute(
+				&collection_id,
+				&nft_id,
+				&origin_of_shell_type_key,
+			)
+			.ok_or(Error::<T>::OriginOfShellTypeNotDetected)?;
+			let race_type: RaceType =
+				Decode::decode(&mut race.as_slice()).expect("[race] should not fail");
+			let career_type: CareerType =
+				Decode::decode(&mut career.as_slice()).expect("[career] should not fail");
+			let origin_of_shell_type: OriginOfShellType =
+				Decode::decode(&mut origin_of_shell_type_value.as_slice())
+					.expect("[origin_of_shell_type] should not fail");
+			// Get Shell Collection next NFT ID
+			let shell_nft_id = pallet_rmrk_core::NextNftId::<T>::get(shell_collection_id);
+			// Burn Origin of Shell NFT then Mint Shell NFT
+			pallet_rmrk_core::Pallet::<T>::burn_nft(
+				Origin::<T>::Signed(owner.clone()).into(),
+				collection_id,
+				nft_id,
+			)?;
+			// Remove Attributes from Uniques pallet
+			pallet_uniques::Pallet::<T>::clear_attribute(
+				origin.clone(),
+				collection_id,
+				Some(nft_id),
+				race_key,
+			)?;
+			pallet_uniques::Pallet::<T>::clear_attribute(
+				origin.clone(),
+				collection_id,
+				Some(nft_id),
+				career_key,
+			)?;
+			pallet_uniques::Pallet::<T>::clear_attribute(
+				origin.clone(),
+				collection_id,
+				Some(nft_id),
+				origin_of_shell_type_key,
+			)?;
+			// Mint Shell NFT to Overlord to add attributes and resource before sending to owner
+			pallet_rmrk_core::Pallet::<T>::mint_nft(
+				origin.clone(),
+				owner.clone(),
+				shell_collection_id,
+				None,
+				None,
+				metadata,
+			)?;
+			// Set Origin of Shell Type, Race and Career attributes for NFT
+			pallet_pw_nft_sale::Pallet::<T>::set_nft_attributes(
+				shell_collection_id,
+				shell_nft_id,
+				origin_of_shell_type,
+				race_type,
+				career_type,
+			)?;
+
+			Self::deposit_event(Event::ShellAwakened {
+				collection_id: shell_collection_id,
+				nft_id: shell_nft_id,
+				owner,
+			});
+
+			Ok(())
+		}
+
+		/// This is an admin function to update origin_of_shells incubation times based on being in
+		/// the top 10 of fed origin_of_shells within that era
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic updating the origin_of_shells incubation times
+		/// - `origin_of_shells`: Vec of a tuple of Origin of Shells and the time to reduce their
+		///   hatch times by
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn update_incubation_time(
+			origin: OriginFor<T>,
+			origin_of_shells: Vec<((CollectionId, NftId), u64)>,
+		) -> DispatchResult {
+			// Ensure OverlordOrigin makes call
+			let sender = ensure_signed(origin)?;
+			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(sender)?;
+			// Iterate through Origin of Shells
+			for ((collection_id, nft_id), reduced_time) in origin_of_shells {
+				// Ensure that the collection is an Origin of Shell Collection
+				ensure!(
+					Self::is_origin_of_shell_collection_id(collection_id),
+					Error::<T>::WrongCollectionId
+				);
+				// Update Hatch Time
+				let old_hatch_time = Self::get_hatch_time(collection_id, nft_id)?;
+				let new_hatch_time = old_hatch_time.saturating_sub(reduced_time);
+				HatchTimes::<T>::insert(collection_id, nft_id, new_hatch_time);
+
+				Self::deposit_event(Event::HatchTimeUpdated {
+					collection_id,
+					nft_id,
+					old_hatch_time,
+					new_hatch_time,
+				});
+			}
+
+			Ok(())
+		}
+
+		/// Privileged function to enable incubation phase for accounts to start the incubation
+		/// process for their Origin of Shells
+		///
+		/// Parameters:
+		/// `origin`: Expected to be the `Overlord` account
+		/// `status`: `bool` value to set for the status in storage
+		#[pallet::weight(0)]
+		pub fn set_can_start_incubation_status(
+			origin: OriginFor<T>,
+			status: bool,
+		) -> DispatchResultWithPostInfo {
+			// Ensure Overlord account is the sender
+			let sender = ensure_signed(origin)?;
+			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(sender)?;
+			// Get official hatch time to set in storage
+			let start_time = T::Time::now().as_secs();
+			let incubation_duration = T::IncubationDurationSec::get();
+			let official_hatch_time = start_time + incubation_duration;
+			// Set official hatch time
+			<OfficialHatchTime<T>>::put(official_hatch_time);
+			// Set status in storage
+			<CanStartIncubation<T>>::put(status);
+
+			Self::deposit_event(Event::CanStartIncubationStatusChanged {
+				status,
+				start_time,
+				official_hatch_time,
+			});
+
+			Ok(Pays::No.into())
+		}
+
+		/// Privileged function to set the collection id for the Awakened Shell collection.
+		///
+		/// Parameters:
+		/// - `origin` - Expected Overlord admin account to set the Shell Collection ID
+		/// - `collection_id` - Collection ID of the Shell Collection
+		#[pallet::weight(0)]
+		pub fn set_shell_collection_id(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+		) -> DispatchResultWithPostInfo {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			pallet_pw_nft_sale::Pallet::<T>::ensure_overlord(sender)?;
+			// If Spirit Collection ID is greater than 0 then the collection ID was already set
+			ensure!(
+				ShellCollectionId::<T>::get().is_none(),
+				Error::<T>::ShellCollectionIdAlreadySet
+			);
+			<ShellCollectionId<T>>::put(collection_id);
+
+			Self::deposit_event(Event::ShellCollectionIdSet { collection_id });
+
+			Ok(Pays::No.into())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T>
+where
+	T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
+{
+	/// Helper function to ensure that the sender owns the origin of shell NFT.
+	///
+	/// Parameters:
+	/// - `sender`: Sender to check if owns the NFT
+	/// - `collection_id`: Collection ID of the NFT
+	/// - `nft_id`: NFT ID of the NFT
+	fn is_owner(sender: &T::AccountId, collection_id: CollectionId, nft_id: NftId) -> bool {
+		if let Some(owner) = pallet_uniques::Pallet::<T>::owner(collection_id, nft_id) {
+			sender == &owner
+		} else {
+			// No owner detected return false
+			false
+		}
+	}
+
+	/// Helper function to check the Collection ID matches Origin of Shell Collection ID.
+	///
+	/// Parameters:
+	/// - `collection_id`: Collection ID to check
+	fn is_origin_of_shell_collection_id(collection_id: CollectionId) -> bool {
+		if let Some(origin_of_shell_collection_id) =
+			pallet_pw_nft_sale::OriginOfShellCollectionId::<T>::get()
+		{
+			collection_id == origin_of_shell_collection_id
+		} else {
+			false
+		}
+	}
+
+	/// Helper function to get hatch time has been assigned for an Origin of Shell.
+	///
+	/// Parameters:
+	/// `collection_id`: Collection ID of the Origin of Shell
+	/// `nft_id`: NFT ID of the Origin of Shell
+	fn get_hatch_time(collection_id: CollectionId, nft_id: NftId) -> Result<u64, Error<T>> {
+		HatchTimes::<T>::get(collection_id, nft_id).ok_or(Error::<T>::NoHatchTimeDetected)
+	}
+
+	/// Helper function to check if the Origin of Shell can hatch
+	///
+	/// Parameters:
+	/// `collection_id`: Collection ID of the Origin of Shell
+	/// `nft_id`: NFT ID of the Origin of Shell
+	fn can_hatch(hatch_time: u64) -> bool {
+		let now = T::Time::now().as_secs();
+		now > hatch_time
+	}
+
+	/// Helper function to get collection id spirit collection
+	fn get_shell_collection_id() -> Result<CollectionId, Error<T>> {
+		let shell_collection_id =
+			ShellCollectionId::<T>::get().ok_or(Error::<T>::ShellCollectionIdNotSet)?;
+		Ok(shell_collection_id)
+	}
+
+	/// Helper function to get new FoodOf<T> struct
+	fn get_new_food_info(
+		era: EraId,
+	) -> FoodInfo<BoundedVec<(CollectionId, NftId), <T as Config>::FoodPerEra>> {
+		FoodInfo {
+			era,
+			origin_of_shells_fed: Default::default(),
+		}
+	}
+}

--- a/pallets/phala-world/src/lib.rs
+++ b/pallets/phala-world/src/lib.rs
@@ -1,0 +1,13 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod incubation;
+pub mod nft_sale;
+
+// Alias
+pub use incubation as pallet_pw_incubation;
+pub use nft_sale as pallet_pw_nft_sale;
+
+#[cfg(test)]
+mod mock;
+mod tests;
+mod traits;

--- a/pallets/phala-world/src/mock.rs
+++ b/pallets/phala-world/src/mock.rs
@@ -181,7 +181,7 @@ parameter_types! {
 
 impl pallet_pw_nft_sale::Config for Test {
 	type Event = Event;
-	type OverlordOrigin = EnsureRoot<AccountId>;
+	type GovernanceOrigin = EnsureRoot<AccountId>;
 	type Currency = Balances;
 	type Time = pallet_timestamp::Pallet<Test>;
 	type SecondsPerEra = SecondsPerEra;

--- a/pallets/phala-world/src/mock.rs
+++ b/pallets/phala-world/src/mock.rs
@@ -1,0 +1,292 @@
+use super::*;
+use crate::{pallet_pw_incubation, pallet_pw_nft_sale, traits};
+
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{
+		AsEnsureOriginWithArg, ConstU32, ConstU64, Everything, GenesisBuild, OnFinalize,
+		OnInitialize,
+	},
+	weights::Weight,
+};
+use frame_system::EnsureRoot;
+use sp_core::{crypto::AccountId32, sr25519::Signature, Pair, Public, H256};
+
+use sp_runtime::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+};
+
+type AccountId = AccountId32;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+type Balance = u128;
+type BlockNumber = u64;
+pub const INIT_TIMESTAMP: u64 = 30_000;
+pub const BLOCK_TIME: u64 = 1_000;
+pub const INIT_TIMESTAMP_SECONDS: u64 = 30;
+pub const BLOCK_TIME_SECONDS: u64 = 1;
+// Configure a mock runtime to test the pallet.
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+		Uniques: pallet_uniques::{Pallet, Storage, Event<T>},
+		RmrkCore: pallet_rmrk_core::{Pallet, Call, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
+		RmrkMarket: pallet_rmrk_market::{Pallet, Call, Event<T>},
+		PWNftSale: pallet_pw_nft_sale::{Pallet, Call, Storage, Event<T>},
+		PWIncubation: pallet_pw_incubation::{Pallet, Call, Storage, Event<T>},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type Origin = Origin;
+	type Call = Call;
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = Event;
+	type BlockHashCount = BlockHashCount;
+	type DbWeight = ();
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<2>;
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 1;
+	pub const MaxReserves: u32 = 50;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type DustRemoval = ();
+	type Event = Event;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxLocks = ();
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+}
+
+parameter_types! {
+	pub ClassBondAmount: Balance = 100;
+	pub MaxMetadataLength: u32 = 256;
+	pub const MaxRecursions: u32 = 10;
+	pub const ResourceSymbolLimit: u32 = 10;
+	pub const PartsLimit: u32 = 10;
+	pub const MaxPriorities: u32 = 3;
+	pub const CollectionSymbolLimit: u32 = 100;
+}
+
+impl pallet_rmrk_core::Config for Test {
+	type Event = Event;
+	type ProtocolOrigin = EnsureRoot<AccountId>;
+	type MaxRecursions = MaxRecursions;
+	type ResourceSymbolLimit = ResourceSymbolLimit;
+	type PartsLimit = PartsLimit;
+	type MaxPriorities = MaxPriorities;
+	type CollectionSymbolLimit = CollectionSymbolLimit;
+}
+
+parameter_types! {
+	pub const ClassDeposit: Balance = 10_000 * PHA; // 1 UNIT deposit to create asset class
+	pub const InstanceDeposit: Balance = 100 * PHA; // 1/100 UNIT deposit to create asset instance
+	pub const KeyLimit: u32 = 32;	// Max 32 bytes per key
+	pub const ValueLimit: u32 = 64;	// Max 64 bytes per value
+	pub const UniquesMetadataDepositBase: Balance = 1000 * PHA;
+	pub const AttributeDepositBase: Balance = 100 * PHA;
+	pub const DepositPerByte: Balance = 10 * PHA;
+	pub const UniquesStringLimit: u32 = 32;
+}
+
+impl pallet_uniques::Config for Test {
+	type Event = Event;
+	type ClassId = u32;
+	type InstanceId = u32;
+	type Currency = Balances;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;
+	type Locker = pallet_rmrk_core::Pallet<Test>;
+	type ClassDeposit = ClassDeposit;
+	type InstanceDeposit = InstanceDeposit;
+	type MetadataDepositBase = UniquesMetadataDepositBase;
+	type AttributeDepositBase = AttributeDepositBase;
+	type DepositPerByte = DepositPerByte;
+	type StringLimit = UniquesStringLimit;
+	type KeyLimit = KeyLimit;
+	type ValueLimit = ValueLimit;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const MinimumOfferAmount: Balance = 50 * UNITS;
+}
+
+impl pallet_rmrk_market::Config for Test {
+	type Event = Event;
+	type ProtocolOrigin = EnsureRoot<AccountId>;
+	type Currency = Balances;
+	type MinimumOfferAmount = MinimumOfferAmount;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 5;
+}
+
+impl pallet_timestamp::Config for Test {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+parameter_types! {
+	pub const SecondsPerEra: u64 = 5 * BLOCK_TIME_SECONDS;
+	pub const MinBalanceToClaimSpirit: Balance = 10 * PHA;
+	pub const LegendaryOriginOfShellPrice: Balance = 1_000_000 * PHA;
+	pub const MagicOriginOfShellPrice: Balance = 1_000 * PHA;
+	pub const PrimeOriginOfShellPrice: Balance = 10 * PHA;
+	pub const MaxMintPerRace: u32 = 2;
+	pub const IterLimit: u32 = 200;
+	pub const FoodPerEra: u32 = 5;
+	pub const MaxFoodFeedSelf: u8 = 2;
+	pub const IncubationDurationSec: u64 = 600;
+}
+
+impl pallet_pw_nft_sale::Config for Test {
+	type Event = Event;
+	type OverlordOrigin = EnsureRoot<AccountId>;
+	type Currency = Balances;
+	type Time = pallet_timestamp::Pallet<Test>;
+	type SecondsPerEra = SecondsPerEra;
+	type MinBalanceToClaimSpirit = MinBalanceToClaimSpirit;
+	type LegendaryOriginOfShellPrice = LegendaryOriginOfShellPrice;
+	type MagicOriginOfShellPrice = MagicOriginOfShellPrice;
+	type PrimeOriginOfShellPrice = PrimeOriginOfShellPrice;
+	type IterLimit = IterLimit;
+}
+
+impl pallet_pw_incubation::Config for Test {
+	type Event = Event;
+	type FoodPerEra = FoodPerEra;
+	type MaxFoodFeedSelf = MaxFoodFeedSelf;
+	type IncubationDurationSec = IncubationDurationSec;
+}
+
+pub type SystemCall = frame_system::Call<Test>;
+pub type BalanceCall = pallet_balances::Call<Test>;
+
+pub fn fast_forward_to(n: u64) {
+	while System::block_number() < n {
+		System::set_block_number(System::block_number() + 1);
+		System::on_finalize(System::block_number());
+		PWNftSale::on_finalize(System::block_number());
+		Timestamp::set_timestamp(System::block_number() * BLOCK_TIME + INIT_TIMESTAMP);
+	}
+}
+// overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+pub const OVERLORD: AccountId = AccountId::new([
+	176, 155, 174, 174, 163, 79, 183, 121, 13, 202, 60, 83, 242, 187, 181, 64, 51, 220, 13, 104,
+	162, 108, 19, 241, 150, 65, 49, 48, 136, 28, 19, 101,
+]);
+// alice_pair = sr25519::Pair::from_seed(b"12345678901234567890123456789012");
+pub const ALICE: AccountId = AccountId::new([
+	116, 28, 8, 160, 111, 65, 197, 150, 96, 143, 103, 116, 37, 155, 217, 4, 51, 4, 173, 250, 93,
+	62, 234, 98, 118, 11, 217, 190, 151, 99, 77, 99,
+]);
+// bob_pair = sr25519::Pair::from_seed(b"09876543210987654321098765432109");
+pub const BOB: AccountId = AccountId::new([
+	250, 140, 153, 155, 88, 13, 83, 23, 193, 161, 236, 241, 58, 213, 107, 213, 230, 33, 38, 154,
+	78, 125, 67, 186, 54, 157, 62, 131, 179, 150, 232, 82,
+]);
+// charlie_pair = sr25519::Pair::from_seed(b"19004878537190048785371900487853");
+pub const CHARLIE: AccountId = AccountId::new([
+	144, 178, 175, 207, 158, 226, 236, 9, 193, 197, 35, 61, 203, 142, 237, 60, 100, 189, 217, 163,
+	184, 20, 116, 158, 252, 151, 72, 114, 185, 129, 78, 43,
+]);
+
+pub const PHA: Balance = 1;
+pub const UNITS: Balance = 100_000_000_000;
+
+pub const MILLISECS_PER_BLOCK: u64 = 3_000;
+// Time is measured by number of blocks.
+pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
+pub const HOURS: BlockNumber = MINUTES * 60;
+pub const DAYS: BlockNumber = HOURS * 24;
+pub const INCUBATION_DURATION_SEC: u64 = 600;
+
+pub struct ExtBuilder;
+
+impl Default for ExtBuilder {
+	fn default() -> Self {
+		ExtBuilder
+	}
+}
+// Build genesis storage according to the mock runtime.
+impl ExtBuilder {
+	pub fn build(self, overlord_key: AccountId32) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Test>()
+			.unwrap();
+
+		pallet_pw_nft_sale::GenesisConfig::<Test> {
+			zero_day: None,
+			overlord: Some(overlord_key),
+			era: 0,
+			can_claim_spirits: false,
+			can_purchase_rare_origin_of_shells: false,
+			can_purchase_prime_origin_of_shells: false,
+			can_preorder_origin_of_shells: false,
+			last_day_of_sale: false,
+			spirit_collection_id: None,
+			origin_of_shell_collection_id: None,
+			is_origin_of_shells_inventory_set: false,
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		pallet_balances::GenesisConfig::<Test> {
+			balances: vec![
+				(OVERLORD, 2_813_308_004 * PHA),
+				(ALICE, 20_000_000 * PHA),
+				(BOB, 15_000 * PHA),
+				(CHARLIE, 150_000 * PHA),
+			],
+		}
+		.assimilate_storage(&mut t)
+		.unwrap();
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| {
+			System::set_block_number(1);
+			Timestamp::set_timestamp(INIT_TIMESTAMP);
+		});
+		ext
+	}
+}

--- a/pallets/phala-world/src/nft_sale.rs
+++ b/pallets/phala-world/src/nft_sale.rs
@@ -46,7 +46,7 @@ pub mod pallet {
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// The origin which may forcibly buy, sell, list/unlist, offer & withdraw offer on Tokens
-		type OverlordOrigin: EnsureOrigin<Self::Origin>;
+		type GovernanceOrigin: EnsureOrigin<Self::Origin>;
 		/// The market currency mechanism.
 		type Currency: ReservableCurrency<Self::AccountId>;
 		/// Time in UnixTime
@@ -761,7 +761,7 @@ pub mod pallet {
 		/// Privileged function set the Overlord Admin account of Phala World
 		///
 		/// Parameters:
-		/// - origin: Expected to be called by `OverlordOrigin`
+		/// - origin: Expected to be called by `GovernanceOrigin`
 		/// - new_overlord: T::AccountId
 		#[pallet::weight(0)]
 		pub fn set_overlord(
@@ -769,7 +769,7 @@ pub mod pallet {
 			new_overlord: T::AccountId,
 		) -> DispatchResultWithPostInfo {
 			// This is a public call, so we ensure that the origin is some signed account.
-			T::OverlordOrigin::ensure_origin(origin)?;
+			T::GovernanceOrigin::ensure_origin(origin)?;
 			let old_overlord = <Overlord<T>>::get();
 
 			Overlord::<T>::put(&new_overlord);

--- a/pallets/phala-world/src/nft_sale.rs
+++ b/pallets/phala-world/src/nft_sale.rs
@@ -1,0 +1,1478 @@
+//! Phala World NFT Sale Pallet
+
+use frame_support::{
+	ensure,
+	traits::{
+		tokens::{nonfungibles::InspectEnumerable, ExistenceRequirement},
+		Currency, UnixTime,
+	},
+	transactional, BoundedVec,
+};
+use frame_system::{ensure_signed, pallet_prelude::*, Origin};
+
+use codec::Encode;
+use sp_core::{sr25519, H256};
+use sp_runtime::DispatchResult;
+use sp_std::prelude::*;
+
+pub use pallet_rmrk_core::types::*;
+pub use pallet_rmrk_market;
+
+pub use crate::traits::{
+	primitives::*, CareerType, NftSaleInfo, OriginOfShellType, OverlordMessage, PreorderInfo,
+	Purpose, RaceType, StatusType,
+};
+use rmrk_traits::primitives::*;
+
+pub type BalanceOf<T> =
+	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+
+pub use self::pallet::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::{dispatch::DispatchResult, pallet_prelude::*, traits::ReservableCurrency};
+	use pallet_rmrk_core::BoundedCollectionSymbolOf;
+
+	type PreorderInfoOf<T> = PreorderInfo<
+		<T as frame_system::Config>::AccountId,
+		BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
+	>;
+
+	/// Configure the pallet by specifying the parameters and types on which it depends.
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_rmrk_core::Config {
+		/// Because this pallet emits events, it depends on the runtime's definition of an event.
+		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+		/// The origin which may forcibly buy, sell, list/unlist, offer & withdraw offer on Tokens
+		type OverlordOrigin: EnsureOrigin<Self::Origin>;
+		/// The market currency mechanism.
+		type Currency: ReservableCurrency<Self::AccountId>;
+		/// Time in UnixTime
+		type Time: UnixTime;
+		/// Seconds per Era that will increment the Era storage value every interval
+		#[pallet::constant]
+		type SecondsPerEra: Get<u64>;
+		/// Minimum amount of PHA to claim a Spirit
+		#[pallet::constant]
+		type MinBalanceToClaimSpirit: Get<BalanceOf<Self>>;
+		/// Price of Legendary Origin of Shell Price
+		#[pallet::constant]
+		type LegendaryOriginOfShellPrice: Get<BalanceOf<Self>>;
+		/// Price of Magic Origin of Shell Price
+		#[pallet::constant]
+		type MagicOriginOfShellPrice: Get<BalanceOf<Self>>;
+		/// Price of Prime Origin of Shell Price
+		#[pallet::constant]
+		type PrimeOriginOfShellPrice: Get<BalanceOf<Self>>;
+		/// Max mint per Race
+		#[pallet::constant]
+		type IterLimit: Get<u32>;
+	}
+
+	#[pallet::pallet]
+	#[pallet::generate_store(pub(super) trait Store)]
+	pub struct Pallet<T>(_);
+
+	/// Preorder index that is the key to the Preorders StorageMap
+	#[pallet::storage]
+	#[pallet::getter(fn preorder_index)]
+	pub type PreorderIndex<T: Config> = StorageValue<_, PreorderId, ValueQuery>;
+
+	/// Preorder info map for user preorders
+	#[pallet::storage]
+	#[pallet::getter(fn preorders)]
+	pub type Preorders<T: Config> = StorageMap<_, Twox64Concat, PreorderId, PreorderInfoOf<T>>;
+
+	/// Origin of Shells inventory
+	#[pallet::storage]
+	#[pallet::getter(fn origin_of_shells_inventory)]
+	pub type OriginOfShellsInventory<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		OriginOfShellType,
+		Blake2_128Concat,
+		RaceType,
+		NftSaleInfo,
+	>;
+
+	/// Phala World Zero Day `BlockNumber` this will be used to determine Eras
+	#[pallet::storage]
+	#[pallet::getter(fn zero_day)]
+	pub(super) type ZeroDay<T: Config> = StorageValue<_, u64>;
+
+	/// The current Era from the initial ZeroDay BlockNumber
+	#[pallet::storage]
+	#[pallet::getter(fn era)]
+	pub type Era<T: Config> = StorageValue<_, EraId, ValueQuery>;
+
+	/// Spirits can be claimed
+	#[pallet::storage]
+	#[pallet::getter(fn can_claim_spirits)]
+	pub type CanClaimSpirits<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Rare Origin of Shells can be purchased
+	#[pallet::storage]
+	#[pallet::getter(fn can_purchase_rare_origin_of_shells)]
+	pub type CanPurchaseRareOriginOfShells<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Origin of Shells can be purchased by whitelist
+	#[pallet::storage]
+	#[pallet::getter(fn can_purchase_prime_origin_of_shells)]
+	pub type CanPurchasePrimeOriginOfShells<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Origin of Shells can be preordered
+	#[pallet::storage]
+	#[pallet::getter(fn can_preorder_origin_of_shells)]
+	pub type CanPreorderOriginOfShells<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Last Day of Sale any Origin of Shell can be purchased
+	#[pallet::storage]
+	#[pallet::getter(fn last_day_of_sale)]
+	pub type LastDayOfSale<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Spirit Collection ID
+	#[pallet::storage]
+	#[pallet::getter(fn spirit_collection_id)]
+	pub type SpiritCollectionId<T: Config> = StorageValue<_, CollectionId, OptionQuery>;
+
+	/// Origin of Shell Collection ID
+	#[pallet::storage]
+	#[pallet::getter(fn origin_of_shell_collection_id)]
+	pub type OriginOfShellCollectionId<T: Config> = StorageValue<_, CollectionId, OptionQuery>;
+
+	/// Career StorageMap count
+	#[pallet::storage]
+	#[pallet::getter(fn career_type_count)]
+	pub type CareerTypeCount<T: Config> = StorageMap<_, Twox64Concat, CareerType, u32, ValueQuery>;
+
+	/// Origin of Shells Inventory has been initialized
+	#[pallet::storage]
+	#[pallet::getter(fn is_origin_of_shells_inventory_set)]
+	pub type IsOriginOfShellsInventorySet<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	/// Overlord Admin account of Phala World
+	#[pallet::storage]
+	pub(super) type Overlord<T: Config> = StorageValue<_, T::AccountId, OptionQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_finalize(_n: T::BlockNumber) {
+			if let Some(zero_day) = <ZeroDay<T>>::get() {
+				let current_time = T::Time::now().as_secs();
+				if current_time > zero_day {
+					let secs_since_zero_day = current_time - zero_day;
+					let current_era = <Era<T>>::get();
+					if secs_since_zero_day / T::SecondsPerEra::get() > current_era {
+						let new_era = Era::<T>::mutate(|era| {
+							*era += 1;
+							*era
+						});
+						Self::deposit_event(Event::NewEra {
+							time: current_time,
+							era: new_era,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	#[pallet::genesis_config]
+	pub struct GenesisConfig<T: Config> {
+		/// `BlockNumber` of Phala World Zero Day
+		pub zero_day: Option<u64>,
+		/// Overlord Admin account of Phala World
+		pub overlord: Option<T::AccountId>,
+		/// Current Era of Phala World
+		pub era: u64,
+		/// bool for if a Spirit is claimable
+		pub can_claim_spirits: bool,
+		/// bool for if a Rare Origin of Shell can be purchased
+		pub can_purchase_rare_origin_of_shells: bool,
+		/// bool for Prime Origin of Shell purchases through whitelist
+		pub can_purchase_prime_origin_of_shells: bool,
+		/// bool for if an Origin of Shell can be preordered
+		pub can_preorder_origin_of_shells: bool,
+		/// bool for the last day of sale for Origin of Shell
+		pub last_day_of_sale: bool,
+		/// CollectionId of Spirit Collection
+		pub spirit_collection_id: Option<CollectionId>,
+		/// CollectionId of Origin of Shell Collection
+		pub origin_of_shell_collection_id: Option<CollectionId>,
+		/// Is Origin of Shells Inventory set?
+		pub is_origin_of_shells_inventory_set: bool,
+	}
+
+	#[cfg(feature = "std")]
+	impl<T: Config> Default for GenesisConfig<T> {
+		fn default() -> Self {
+			Self {
+				zero_day: None,
+				overlord: None,
+				era: 0,
+				can_claim_spirits: false,
+				can_purchase_rare_origin_of_shells: false,
+				can_purchase_prime_origin_of_shells: false,
+				can_preorder_origin_of_shells: false,
+				last_day_of_sale: false,
+				spirit_collection_id: None,
+				origin_of_shell_collection_id: None,
+				is_origin_of_shells_inventory_set: false,
+			}
+		}
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> GenesisBuild<T> for GenesisConfig<T>
+	where
+		T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
+	{
+		fn build(&self) {
+			if let Some(ref zero_day) = self.zero_day {
+				<ZeroDay<T>>::put(zero_day);
+			}
+			if let Some(ref overlord) = self.overlord {
+				<Overlord<T>>::put(overlord);
+			}
+			let era = self.era;
+			<Era<T>>::put(era);
+			let can_claim_spirits = self.can_claim_spirits;
+			<CanClaimSpirits<T>>::put(can_claim_spirits);
+			let can_purchase_rare_origin_of_shells = self.can_purchase_rare_origin_of_shells;
+			<CanPurchaseRareOriginOfShells<T>>::put(can_purchase_rare_origin_of_shells);
+			let can_purchase_prime_origin_of_shells = self.can_purchase_prime_origin_of_shells;
+			<CanPurchasePrimeOriginOfShells<T>>::put(can_purchase_prime_origin_of_shells);
+			let can_preorder_origin_of_shells = self.can_preorder_origin_of_shells;
+			<CanPreorderOriginOfShells<T>>::put(can_preorder_origin_of_shells);
+			let last_day_of_sale = self.last_day_of_sale;
+			<LastDayOfSale<T>>::put(last_day_of_sale);
+			if let Some(spirit_collection_id) = self.spirit_collection_id {
+				<SpiritCollectionId<T>>::put(spirit_collection_id);
+			}
+			if let Some(origin_of_shell_collection_id) = self.origin_of_shell_collection_id {
+				<OriginOfShellCollectionId<T>>::put(origin_of_shell_collection_id);
+			}
+			let is_origin_of_shells_inventory_set = self.is_origin_of_shells_inventory_set;
+			<IsOriginOfShellsInventorySet<T>>::put(is_origin_of_shells_inventory_set);
+		}
+	}
+
+	// Pallets use events to inform users when important changes are made.
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		/// Phala World clock zero day started
+		WorldClockStarted { start_time: u64 },
+		/// Start of a new era
+		NewEra { time: u64, era: u64 },
+		/// Spirit has been claimed
+		SpiritClaimed {
+			owner: T::AccountId,
+			collection_id: CollectionId,
+			nft_id: NftId,
+		},
+		/// A chance to get an Origin of Shell through preorder
+		OriginOfShellPreordered {
+			owner: T::AccountId,
+			preorder_id: PreorderId,
+		},
+		/// Origin of Shell minted from the preorder
+		OriginOfShellMinted {
+			origin_of_shell_type: OriginOfShellType,
+			collection_id: CollectionId,
+			nft_id: NftId,
+			owner: T::AccountId,
+			race: RaceType,
+			career: CareerType,
+		},
+		/// Spirit collection id was set
+		SpiritCollectionIdSet { collection_id: CollectionId },
+		/// Origin of Shell collection id was set
+		OriginOfShellCollectionIdSet { collection_id: CollectionId },
+		/// Origin of Shell inventory updated
+		OriginOfShellInventoryUpdated {
+			origin_of_shell_type: OriginOfShellType,
+		},
+		/// Spirit Claims status has changed
+		ClaimSpiritStatusChanged { status: bool },
+		/// Purchase Rare Origin of Shells status has changed
+		PurchaseRareOriginOfShellsStatusChanged { status: bool },
+		/// Purchase Prime Origin of Shells status changed
+		PurchasePrimeOriginOfShellsStatusChanged { status: bool },
+		/// Preorder Origin of Shells status has changed
+		PreorderOriginOfShellsStatusChanged { status: bool },
+		/// Chosen preorder was minted to owner
+		ChosenPreorderMinted {
+			preorder_id: PreorderId,
+			owner: T::AccountId,
+		},
+		/// Not chosen preorder was refunded to owner
+		NotChosenPreorderRefunded {
+			preorder_id: PreorderId,
+			owner: T::AccountId,
+		},
+		/// Last Day of Sale status has changed
+		LastDayOfSaleStatusChanged { status: bool },
+		OverlordChanged {
+			old_overlord: Option<T::AccountId>,
+			new_overlord: T::AccountId,
+		},
+		/// Origin of Shells Inventory was set
+		OriginOfShellsInventoryWasSet { status: bool },
+	}
+
+	// Errors inform users that something went wrong.
+	#[pallet::error]
+	pub enum Error<T> {
+		WorldClockAlreadySet,
+		SpiritClaimNotAvailable,
+		RareOriginOfShellPurchaseNotAvailable,
+		PrimeOriginOfShellPurchaseNotAvailable,
+		PreorderOriginOfShellNotAvailable,
+		PreorderClaimNotAvailable,
+		SpiritAlreadyClaimed,
+		InvalidSpiritClaim,
+		InvalidMetadata,
+		MustOwnSpiritToPurchase,
+		OriginOfShellAlreadyPurchased,
+		BelowMinimumBalanceThreshold,
+		WhitelistVerificationFailed,
+		InvalidPurchase,
+		NoAvailablePreorderId,
+		PreorderClaimNotDetected,
+		RefundClaimNotDetected,
+		PreorderIsPending,
+		PreordersCorrupted,
+		NotPreorderOwner,
+		RaceMintMaxReached,
+		OverlordNotSet,
+		RequireOverlordAccount,
+		InvalidStatusType,
+		WrongOriginOfShellType,
+		SpiritCollectionNotSet,
+		SpiritCollectionIdAlreadySet,
+		OriginOfShellCollectionNotSet,
+		OriginOfShellCollectionIdAlreadySet,
+		OriginOfShellInventoryCorrupted,
+		OriginOfShellInventoryAlreadySet,
+		UnableToAddAttributes,
+		KeyTooLong,
+	}
+
+	// Dispatchable functions allows users to interact with the pallet and invoke state changes.
+	// These functions materialize as "extrinsics", which are often compared to transactions.
+	// Dispatchable functions must be annotated with a weight and must return a DispatchResult.
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
+	{
+		/// Claim a spirit for any account with at least 10 PHA in their account
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic.
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn claim_spirit(origin: OriginFor<T>) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+			ensure!(
+				CanClaimSpirits::<T>::get(),
+				Error::<T>::SpiritClaimNotAvailable
+			);
+			let overlord = Self::overlord()?;
+			// Check Balance has minimum required
+			ensure!(
+				<T as pallet::Config>::Currency::can_reserve(
+					&sender,
+					T::MinBalanceToClaimSpirit::get()
+				),
+				Error::<T>::BelowMinimumBalanceThreshold
+			);
+			// Mint Spirit NFT
+			Self::do_mint_spirit_nft(overlord, sender)?;
+
+			Ok(())
+		}
+
+		/// Redeem spirit function is called when an account has a `SpiritClaimTicket` that enables
+		/// an account to acquire a Spirit NFT without the 10 PHA minimum requirement, such that,
+		/// the account has a valid `SpiritClaimTicket` signed by the Overlord admin account.
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic.
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn redeem_spirit(
+			origin: OriginFor<T>,
+			signature: sr25519::Signature,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+			ensure!(
+				CanClaimSpirits::<T>::get(),
+				Error::<T>::SpiritClaimNotAvailable
+			);
+			let overlord = Self::overlord()?;
+			// verify the claim ticket
+			ensure!(
+				Self::verify_claim(&overlord, &sender, signature, Purpose::RedeemSpirit),
+				Error::<T>::InvalidSpiritClaim
+			);
+			// Mint Spirit NFT
+			Self::do_mint_spirit_nft(overlord, sender)?;
+
+			Ok(())
+		}
+
+		/// Buy a rare origin_of_shell of either type Magic or Legendary. Both Origin of Shell types
+		/// will have a set price. These will also be limited in quantity and on a first come, first
+		/// serve basis.
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic.
+		/// - origin_of_shell_type: The type of origin_of_shell to be purchased.
+		/// - race: The race of the origin_of_shell chosen by the user.
+		/// - career: The career of the origin_of_shell chosen by the user or auto-generated based
+		///   on metadata
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn buy_rare_origin_of_shell(
+			origin: OriginFor<T>,
+			origin_of_shell_type: OriginOfShellType,
+			race: RaceType,
+			career: CareerType,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+			ensure!(
+				CanPurchaseRareOriginOfShells::<T>::get(),
+				Error::<T>::RareOriginOfShellPurchaseNotAvailable
+			);
+			let overlord = Self::overlord()?;
+			// Get Origin of Shell Price based on Origin of ShellType
+			let origin_of_shell_price = match origin_of_shell_type {
+				OriginOfShellType::Legendary => T::LegendaryOriginOfShellPrice::get(),
+				OriginOfShellType::Magic => T::MagicOriginOfShellPrice::get(),
+				_ => return Err(Error::<T>::InvalidPurchase.into()),
+			};
+			// Mint origin of shell
+			Self::do_mint_origin_of_shell_nft(
+				overlord,
+				sender,
+				origin_of_shell_type,
+				race,
+				career,
+				origin_of_shell_price,
+				!LastDayOfSale::<T>::get(),
+			)?;
+
+			Ok(())
+		}
+
+		/// Accounts that have been whitelisted can purchase an Origin of Shell. The only Origin of
+		/// Shell type available for this purchase are Prime
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic purchasing the Prime Origin of Shell
+		/// - message: OverlordMessage with account and purpose
+		/// - signature: The signature of the account that is claiming the spirit.
+		/// - race: The race that the user has chosen (limited # of races)
+		/// - career: The career that the user has chosen (unlimited careers)
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn buy_prime_origin_of_shell(
+			origin: OriginFor<T>,
+			signature: sr25519::Signature,
+			race: RaceType,
+			career: CareerType,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin.clone())?;
+			let is_last_day_of_sale = LastDayOfSale::<T>::get();
+			ensure!(
+				CanPurchasePrimeOriginOfShells::<T>::get() || is_last_day_of_sale,
+				Error::<T>::PrimeOriginOfShellPurchaseNotAvailable
+			);
+
+			let overlord = Self::overlord()?;
+			// Check if valid message purpose is 'BuyPrimeOriginOfShells' and verify whitelist
+			// account
+			ensure!(
+				Self::verify_claim(
+					&overlord,
+					&sender,
+					signature,
+					Purpose::BuyPrimeOriginOfShells
+				) || is_last_day_of_sale,
+				Error::<T>::WhitelistVerificationFailed
+			);
+			// Get Prime Origin of Shell price
+			let origin_of_shell_price = T::PrimeOriginOfShellPrice::get();
+			// Mint origin of shell
+			Self::do_mint_origin_of_shell_nft(
+				overlord,
+				sender,
+				OriginOfShellType::Prime,
+				race,
+				career,
+				origin_of_shell_price,
+				!is_last_day_of_sale,
+			)?;
+
+			Ok(())
+		}
+
+		/// Users can pre-order an Origin of Shell. This will enable users that are non-whitelisted
+		/// to be added to the queue of users that can claim Origin of Shells. Those that come after
+		/// the whitelist pre-sale will be able to win the chance to acquire an Origin of Shell
+		/// based on their choice of race and career as they will have a limited quantity.
+		///
+		/// Parameters:
+		/// - origin: The origin of the extrinsic preordering the origin_of_shell
+		/// - race: The race that the user has chosen (limited # of races)
+		/// - career: The career that the user has chosen (limited # of careers)
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn preorder_origin_of_shell(
+			origin: OriginFor<T>,
+			race: RaceType,
+			career: CareerType,
+		) -> DispatchResult {
+			let sender = ensure_signed(origin)?;
+			ensure!(
+				CanPreorderOriginOfShells::<T>::get(),
+				Error::<T>::PreorderOriginOfShellNotAvailable
+			);
+			// Has Spirit Collection been set
+			let spirit_collection_id = Self::get_spirit_collection_id()?;
+			// Must have origin of shell collection created
+			ensure!(
+				Self::owns_nft_in_collection(&sender, spirit_collection_id),
+				Error::<T>::OriginOfShellAlreadyPurchased
+			);
+
+			// Get preorder_id for new preorder
+			let preorder_id =
+				<PreorderIndex<T>>::try_mutate(|n| -> Result<PreorderId, DispatchError> {
+					let id = *n;
+					ensure!(
+						id != PreorderId::max_value(),
+						Error::<T>::NoAvailablePreorderId
+					);
+					*n += 1;
+					Ok(id)
+				})?;
+			// Verify metadata
+			let metadata = Self::get_empty_metadata();
+			let preorder = PreorderInfo {
+				owner: sender.clone(),
+				race,
+				career,
+				metadata,
+			};
+			// Reserve currency for the preorder at the Prime origin_of_shell price
+			<T as pallet::Config>::Currency::reserve(&sender, T::PrimeOriginOfShellPrice::get())?;
+
+			Preorders::<T>::insert(preorder_id, preorder);
+
+			Self::deposit_event(Event::OriginOfShellPreordered {
+				owner: sender,
+				preorder_id,
+			});
+
+			Ok(())
+		}
+
+		/// This is an admin only function that will mint the list of `Chosen` preorders and will
+		/// mint the Origin of Shell NFT to the preorder owner.
+		///
+		/// Parameters:
+		/// `origin`: Expected to come from Overlord admin account
+		/// `preorders`: Vec of Preorder IDs that were `Chosen`
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn mint_chosen_preorders(
+			origin: OriginFor<T>,
+			preorders: Vec<PreorderId>,
+		) -> DispatchResult {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender.clone())?;
+			// Get price of prime origin of shell
+			let origin_of_shell_price = T::PrimeOriginOfShellPrice::get();
+			// Get iter limit
+			let iter_limit = T::IterLimit::get();
+			let mut index = 0;
+			// Iterate through the preorder_statuses Vec
+			for preorder_id in preorders {
+				if index < iter_limit {
+					// Get the chosen preorder
+					let preorder_info = Preorders::<T>::take(preorder_id)
+						.ok_or(Error::<T>::NoAvailablePreorderId)?;
+					// Get owner of preorder
+					let preorder_owner = preorder_info.owner.clone();
+					// Unreserve from owner account
+					<T as pallet::Config>::Currency::unreserve(
+						&preorder_owner,
+						origin_of_shell_price,
+					);
+					// Mint origin of shell
+					Self::do_mint_origin_of_shell_nft(
+						sender.clone(),
+						preorder_owner.clone(),
+						OriginOfShellType::Prime,
+						preorder_info.race,
+						preorder_info.career,
+						origin_of_shell_price,
+						false,
+					)?;
+
+					Self::deposit_event(Event::ChosenPreorderMinted {
+						preorder_id,
+						owner: preorder_owner,
+					});
+					index += 1;
+				} else {
+					// Break from iterator to ensure block size doesn't grow too large. Re-call this
+					// function and it will start from where it left off.
+					break;
+				}
+			}
+
+			Ok(())
+		}
+
+		/// This is an admin only function that will be used to refund the preorders that were not
+		/// selected during the preorders drawing.
+		///
+		/// Parameters:
+		/// `origin`: Expected to come from Overlord admin account
+		/// `preorders`: Preorder ids of the not chosen preorders
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn refund_not_chosen_preorders(
+			origin: OriginFor<T>,
+			preorders: Vec<PreorderId>,
+		) -> DispatchResult {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// Get price of prime origin of shell
+			let origin_of_shell_price = T::PrimeOriginOfShellPrice::get();
+			// Get iter limit
+			let iter_limit = T::IterLimit::get();
+			let mut index = 0;
+			// Iterate through the preorder_statuses Vec
+			for preorder_id in preorders {
+				if index < iter_limit {
+					// Get the PreorderInfoOf<T>
+					let preorder_info = Preorders::<T>::take(preorder_id)
+						.ok_or(Error::<T>::NoAvailablePreorderId)?;
+					// Refund reserved currency back to owner account
+					<T as pallet::Config>::Currency::unreserve(
+						&preorder_info.owner,
+						origin_of_shell_price,
+					);
+
+					Self::deposit_event(Event::NotChosenPreorderRefunded {
+						preorder_id,
+						owner: preorder_info.owner,
+					});
+					index += 1;
+				} else {
+					// Break from iterator to ensure block size doesn't grow too large. Re-call this
+					// function and it will start from where it left off.
+					break;
+				}
+			}
+
+			Ok(())
+		}
+
+		/// Privileged function set the Overlord Admin account of Phala World
+		///
+		/// Parameters:
+		/// - origin: Expected to be called by `OverlordOrigin`
+		/// - new_overlord: T::AccountId
+		#[pallet::weight(0)]
+		pub fn set_overlord(
+			origin: OriginFor<T>,
+			new_overlord: T::AccountId,
+		) -> DispatchResultWithPostInfo {
+			// This is a public call, so we ensure that the origin is some signed account.
+			T::OverlordOrigin::ensure_origin(origin)?;
+			let old_overlord = <Overlord<T>>::get();
+
+			Overlord::<T>::put(&new_overlord);
+			Self::deposit_event(Event::OverlordChanged {
+				old_overlord,
+				new_overlord,
+			});
+			// GameOverlord user does not pay a fee
+			Ok(Pays::No.into())
+		}
+
+		/// Phala World Zero Day is set to begin the tracking of the official time starting at the
+		/// current timestamp when `initialize_world_clock` is called by the `Overlord`
+		///
+		/// Parameters:
+		/// `origin`: Expected to be called by `Overlord` admin account
+		#[pallet::weight(0)]
+		pub fn initialize_world_clock(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// Ensure ZeroDay is None as this can only be set once
+			ensure!(Self::zero_day() == None, Error::<T>::WorldClockAlreadySet);
+
+			let zero_day = T::Time::now().as_secs();
+
+			ZeroDay::<T>::put(zero_day);
+			Self::deposit_event(Event::WorldClockStarted {
+				start_time: zero_day,
+			});
+
+			Ok(Pays::No.into())
+		}
+
+		/// Privileged function to set the status for one of the defined StatusTypes like
+		/// ClaimSpirits, PurchaseRareOriginOfShells, or PreorderOriginOfShells to enable
+		/// functionality in Phala World
+		///
+		/// Parameters:
+		/// - `origin` - Expected Overlord admin account to set the status
+		/// - `status` - `bool` to set the status to
+		/// - `status_type` - `StatusType` to set the status for
+		#[pallet::weight(0)]
+		pub fn set_status_type(
+			origin: OriginFor<T>,
+			status: bool,
+			status_type: StatusType,
+		) -> DispatchResultWithPostInfo {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// Match StatusType and call helper function to set status
+			match status_type {
+				StatusType::ClaimSpirits => Self::set_claim_spirits_status(status)?,
+				StatusType::PurchaseRareOriginOfShells => {
+					Self::set_purchase_rare_origin_of_shells_status(status)?
+				}
+				StatusType::PurchasePrimeOriginOfShells => {
+					Self::set_purchase_prime_origin_of_shells_status(status)?
+				}
+				StatusType::PreorderOriginOfShells => {
+					Self::set_preorder_origin_of_shells_status(status)?
+				}
+				StatusType::LastDayOfSale => Self::set_last_day_of_sale_status(status)?,
+			}
+			Ok(Pays::No.into())
+		}
+
+		/// Initialize the settings for the non-whitelist preorder period amount of races &
+		/// giveaways available for the Origin of Shell NFTs. This is a privileged function and can
+		/// only be executed by the Overlord account. This will call the helper function
+		/// `set_initial_origin_of_shell_inventory`
+		///
+		/// Parameters:
+		/// - `origin` - Expected Overlord admin account
+		#[pallet::weight(0)]
+		pub fn init_origin_of_shell_type_counts(origin: OriginFor<T>) -> DispatchResult {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// Call helper function
+			Self::set_initial_origin_of_shell_inventory()?;
+			Self::deposit_event(Event::OriginOfShellsInventoryWasSet { status: true });
+			Ok(())
+		}
+
+		/// Update for the non-whitelist preorder period amount of races & giveaways available for
+		/// the Origin of Shell NFTs. This is a privileged function and can only be executed by the
+		/// Overlord account. Update the OriginOfShellInventory counts by incrementing them based on
+		/// the defined counts
+		///
+		/// Parameters:
+		/// - `origin` - Expected Overlord admin account
+		/// - `origin_of_shell_type` - Type of Origin of Shell
+		/// - `for_sale_count` - Number of Origin of Shells for sale
+		/// - `giveaway_count` - Number of Origin of Shells for giveaways
+		/// - `reserve_count` - Number of Origin of Shells to be reserved
+		#[pallet::weight(0)]
+		pub fn update_origin_of_shell_type_counts(
+			origin: OriginFor<T>,
+			origin_of_shell_type: OriginOfShellType,
+			for_sale_count: u32,
+			giveaway_count: u32,
+		) -> DispatchResult {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// Ensure they are updating the OriginOfShellType::Prime
+			ensure!(
+				origin_of_shell_type == OriginOfShellType::Prime,
+				Error::<T>::WrongOriginOfShellType
+			);
+			// Mutate the existing storage for the Prime Origin of Shells
+			Self::update_nft_sale_info(
+				origin_of_shell_type,
+				RaceType::AISpectre,
+				for_sale_count,
+				giveaway_count,
+			);
+			Self::update_nft_sale_info(
+				origin_of_shell_type,
+				RaceType::Cyborg,
+				for_sale_count,
+				giveaway_count,
+			);
+			Self::update_nft_sale_info(
+				origin_of_shell_type,
+				RaceType::Pandroid,
+				for_sale_count,
+				giveaway_count,
+			);
+			Self::update_nft_sale_info(
+				origin_of_shell_type,
+				RaceType::XGene,
+				for_sale_count,
+				giveaway_count,
+			);
+
+			Self::deposit_event(Event::OriginOfShellInventoryUpdated {
+				origin_of_shell_type,
+			});
+
+			Ok(())
+		}
+
+		/// Privileged function to set the collection id for the Spirits collection
+		///
+		/// Parameters:
+		/// - `origin` - Expected Overlord admin account to set the Spirit Collection ID
+		/// - `collection_id` - Collection ID of the Spirit Collection
+		#[pallet::weight(0)]
+		pub fn set_spirit_collection_id(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+		) -> DispatchResultWithPostInfo {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// If Spirit Collection ID is greater than 0 then the collection ID was already set
+			ensure!(
+				SpiritCollectionId::<T>::get().is_none(),
+				Error::<T>::SpiritCollectionIdAlreadySet
+			);
+			<SpiritCollectionId<T>>::put(collection_id);
+
+			Self::deposit_event(Event::SpiritCollectionIdSet { collection_id });
+
+			Ok(Pays::No.into())
+		}
+
+		/// Privileged function to set the collection id for the Origin of Shell collection
+		///
+		/// Parameters:
+		/// - `origin` - Expected Overlord admin account to set the Origin of Shell Collection ID
+		/// - `collection_id` - Collection ID of the Origin of Shell Collection
+		#[pallet::weight(0)]
+		pub fn set_origin_of_shell_collection_id(
+			origin: OriginFor<T>,
+			collection_id: CollectionId,
+		) -> DispatchResultWithPostInfo {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin)?;
+			Self::ensure_overlord(sender)?;
+			// If Origin of Shell Collection ID is greater than 0 then the collection ID was already
+			// set
+			ensure!(
+				OriginOfShellCollectionId::<T>::get().is_none(),
+				Error::<T>::OriginOfShellCollectionIdAlreadySet
+			);
+			<OriginOfShellCollectionId<T>>::put(collection_id);
+
+			Self::deposit_event(Event::OriginOfShellCollectionIdSet { collection_id });
+
+			Ok(Pays::No.into())
+		}
+
+		/// Privileged function to allow Overlord to mint the Spirit, Origin of Shell or Shell NFT
+		/// Collections. This allows for only Overlord to be able to mint Collections on Phala &
+		/// prevents other users from calling the RMRK Core `create_collection` function.
+		///
+		/// Parameters:
+		/// - `origin`: Expected to be called by Overlord
+		/// - `metadata`: Metadata pertaining to the collection
+		/// - `max`: Optional max u32 for the size of the collection
+		/// - `symbol`: BoundedString of the collection's symbol i.e 'OVRLD'
+		#[pallet::weight(10_000 + T::DbWeight::get().reads_writes(1,1))]
+		#[transactional]
+		pub fn pw_create_collection(
+			origin: OriginFor<T>,
+			metadata: BoundedVec<u8, T::StringLimit>,
+			max: Option<u32>,
+			symbol: BoundedCollectionSymbolOf<T>,
+		) -> DispatchResult {
+			// Ensure Overlord account makes call
+			let sender = ensure_signed(origin.clone())?;
+			Self::ensure_overlord(sender)?;
+			// Call the RMRK Core function
+			pallet_rmrk_core::Pallet::<T>::create_collection(origin, metadata, max, symbol)?;
+
+			Ok(())
+		}
+	}
+}
+
+impl<T: Config> Pallet<T>
+where
+	T: pallet_uniques::Config<ClassId = CollectionId, InstanceId = NftId>,
+{
+	/// Verify the sender making the claim is the Account signed by the Overlord admin account and
+	/// verify the purpose of the `OverlordMessage` which will be either `RedeemSpirit` or
+	/// `BuyPrimeOriginOfShells`
+	///
+	/// Parameters:
+	/// - `overlord`: Overlord admin account
+	/// - `sender`: Sender that redeemed the claim
+	/// - `signature`: sr25519::Signature of the expected account making the claim
+	/// - `message`: OverlordMessage that contains the account and purpose
+	/// - `purpose`: Expected Purpose
+	pub fn verify_claim(
+		overlord: &T::AccountId,
+		sender: &T::AccountId,
+		signature: sr25519::Signature,
+		purpose: Purpose,
+	) -> bool {
+		let message = OverlordMessage {
+			account: sender.clone(),
+			purpose,
+		};
+		let encoded_message = Encode::encode(&message);
+		let encode_overlord = T::AccountId::encode(overlord);
+		let h256_overlord = H256::from_slice(&encode_overlord);
+		let overlord_key = sr25519::Public::from_h256(h256_overlord);
+		// verify claim
+		sp_io::crypto::sr25519_verify(&signature, &encoded_message, &overlord_key)
+	}
+
+	/// Helper function to ensure Overlord account is the sender
+	///
+	/// Parameters:
+	/// - `sender`: Account origin that made the call to check if Overlord account
+	pub(crate) fn ensure_overlord(sender: T::AccountId) -> DispatchResult {
+		ensure!(
+			Self::overlord().map_or(false, |k| sender == k),
+			Error::<T>::RequireOverlordAccount
+		);
+		Ok(())
+	}
+
+	/// Helper function to get the Overlord admin account
+	pub(crate) fn overlord() -> Result<T::AccountId, Error<T>> {
+		Overlord::<T>::get().ok_or(Error::<T>::OverlordNotSet)
+	}
+
+	/// Set Spirit Claims with the Overlord admin Account to allow users to claim their
+	/// Spirits through the `claim_spirits()` function
+	///
+	/// Parameters:
+	/// - `status`: Status to set CanClaimSpirits StorageValue
+	fn set_claim_spirits_status(status: bool) -> DispatchResult {
+		<CanClaimSpirits<T>>::put(status);
+
+		Self::deposit_event(Event::ClaimSpiritStatusChanged { status });
+
+		Ok(())
+	}
+
+	/// Set Rare Origin of Shells status for purchase with the Overlord Admin Account to allow
+	/// users to purchase either Legendary or Magic Origin of Shells
+	///
+	/// Parameters:
+	/// `status`: Status to set CanPurchaseRareOriginOfShells StorageValue
+	fn set_purchase_rare_origin_of_shells_status(status: bool) -> DispatchResult {
+		<CanPurchaseRareOriginOfShells<T>>::put(status);
+
+		Self::deposit_event(Event::PurchaseRareOriginOfShellsStatusChanged { status });
+
+		Ok(())
+	}
+
+	/// Set Prime Origin of Shells status for purchase with the Overlord Admin Account to allow
+	/// users to purchase Prime Origin of Shells
+	///
+	/// Parameters:
+	/// `status`: Status to set CanPurchaseOriginOfShellsWhitelist StorageValue
+	fn set_purchase_prime_origin_of_shells_status(status: bool) -> DispatchResult {
+		<CanPurchasePrimeOriginOfShells<T>>::put(status);
+
+		Self::deposit_event(Event::PurchasePrimeOriginOfShellsStatusChanged { status });
+
+		Ok(())
+	}
+
+	/// Set status of Preordering origin_of_shells with the Overlord Admin Account to allow
+	/// users to preorder origin_of_shells through the `preorder_origin_of_shell()` function
+	///
+	/// Parameters:
+	/// - `status`: Status to set CanPreorderOriginOfShells StorageValue
+	fn set_preorder_origin_of_shells_status(status: bool) -> DispatchResult {
+		<CanPreorderOriginOfShells<T>>::put(status);
+
+		Self::deposit_event(Event::PreorderOriginOfShellsStatusChanged { status });
+
+		Ok(())
+	}
+
+	/// Set status of last day of sale for origin of shells with the Overlord Admin Account to allow
+	/// users to purchase any origin of shell
+	///
+	/// Parameters:
+	/// - `status`: Status to set LastDayOfSale StorageValue
+	fn set_last_day_of_sale_status(status: bool) -> DispatchResult {
+		<LastDayOfSale<T>>::put(status);
+
+		Self::deposit_event(Event::PreorderOriginOfShellsStatusChanged { status });
+
+		Ok(())
+	}
+
+	/// Set initial OriginOfShellInventory values in the StorageDoubleMap. Key1 will be of
+	/// OriginOfShellType and Key2 will be the RaceType and the Value will be NftSaleInfo struct
+	/// containing the information for the NFT sale. Initial config will look as follows:
+	/// `<Legendary>,<RaceType> => NftSaleInfo { race_count: 0, career_count: 0,
+	/// race_for_sale_count: 1, race_giveaway_count: 0, race_reserved_count: 1 }`
+	/// `<Magic>,<RaceType> => NftSaleInfo { race_count: 0, career_count: 0, race_for_sale_count:
+	/// 15, race_giveaway_count: 0, race_reserved_count: 5 }`
+	/// `<Prime>,<RaceType> => NftSaleInfo { race_count: 0, career_count: 0, race_for_sale_count:
+	/// 1250, race_giveaway_count: 50, race_reserved_count: 0 }`
+	fn set_initial_origin_of_shell_inventory() -> DispatchResult {
+		// 3 OriginOfShellType Prime, Magic & Legendary and 4 different RaceType Cyborg, AISpectre,
+		// XGene & Pandroid
+		ensure!(
+			!IsOriginOfShellsInventorySet::<T>::get(),
+			Error::<T>::OriginOfShellInventoryAlreadySet
+		);
+		let legendary_nft_sale_info = NftSaleInfo {
+			race_count: 0,
+			race_for_sale_count: 1,
+			race_giveaway_count: 0,
+			race_reserved_count: 1,
+		};
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Legendary,
+			RaceType::AISpectre,
+			legendary_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Legendary,
+			RaceType::Cyborg,
+			legendary_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Legendary,
+			RaceType::Pandroid,
+			legendary_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Legendary,
+			RaceType::XGene,
+			legendary_nft_sale_info,
+		);
+		let magic_nft_sale_info = NftSaleInfo {
+			race_count: 0,
+			race_for_sale_count: 10,
+			race_giveaway_count: 0,
+			race_reserved_count: 10,
+		};
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Magic,
+			RaceType::AISpectre,
+			magic_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Magic,
+			RaceType::Cyborg,
+			magic_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Magic,
+			RaceType::Pandroid,
+			magic_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Magic,
+			RaceType::XGene,
+			magic_nft_sale_info,
+		);
+		let prime_nft_sale_info = NftSaleInfo {
+			race_count: 0,
+			race_for_sale_count: 1250,
+			race_giveaway_count: 0,
+			race_reserved_count: 0,
+		};
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Prime,
+			RaceType::AISpectre,
+			prime_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Prime,
+			RaceType::Cyborg,
+			prime_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Prime,
+			RaceType::Pandroid,
+			prime_nft_sale_info,
+		);
+		OriginOfShellsInventory::<T>::insert(
+			OriginOfShellType::Prime,
+			RaceType::XGene,
+			prime_nft_sale_info,
+		);
+		// Set IsOriginOfShellsInventorySet to true
+		IsOriginOfShellsInventorySet::<T>::put(true);
+
+		Ok(())
+	}
+
+	/// Update the NftSaleInfo for a given OriginOfShellType and RaceType
+	///
+	/// Parameters:
+	/// - `origin_of_shell_type`: OriginOfShellType to update in OriginOfShellInventory
+	/// - `race`: RaceType to update in OriginOfShellInventory
+	/// - `for_sale_count`: count to increment the for sale count
+	/// - `giveaway_count`: count to increment the race giveaway count
+	fn update_nft_sale_info(
+		origin_of_shell_type: OriginOfShellType,
+		race: RaceType,
+		for_sale_count: u32,
+		giveaway_count: u32,
+	) {
+		OriginOfShellsInventory::<T>::mutate(origin_of_shell_type, race, |nft_sale_info| {
+			if let Some(nft_sale_info) = nft_sale_info {
+				nft_sale_info.race_for_sale_count = nft_sale_info
+					.race_for_sale_count
+					.saturating_add(for_sale_count);
+				nft_sale_info.race_giveaway_count = nft_sale_info
+					.race_giveaway_count
+					.saturating_add(giveaway_count);
+			}
+		});
+	}
+
+	/// Mint a Spirit NFT helper function that will mint a Spirit NFT to new owner
+	///
+	/// Parameters:
+	/// - `overlord`: Overlord account owns the NFT collection and will mint the NFT and freeze it
+	/// - `sender`: New owner of the Spirit NFT
+	fn do_mint_spirit_nft(overlord: T::AccountId, sender: T::AccountId) -> DispatchResult {
+		// Has Spirit Collection been set
+		let spirit_collection_id = Self::get_spirit_collection_id()?;
+		// Check if sender already claimed a spirit
+		ensure!(
+			!Self::owns_nft_in_collection(&sender, spirit_collection_id),
+			Error::<T>::SpiritAlreadyClaimed
+		);
+		// Empty metadata
+		let metadata = Self::get_empty_metadata();
+		// Get NFT ID to be minted
+		let spirit_nft_id = pallet_rmrk_core::NextNftId::<T>::get(spirit_collection_id);
+		// Mint new Spirit and transfer to sender
+		pallet_rmrk_core::Pallet::<T>::mint_nft(
+			Origin::<T>::Signed(overlord.clone()).into(),
+			sender.clone(),
+			spirit_collection_id,
+			None,
+			None,
+			metadata,
+		)?;
+		// Freeze NFT so it cannot be transferred
+		pallet_uniques::Pallet::<T>::freeze(
+			Origin::<T>::Signed(overlord).into(),
+			spirit_collection_id,
+			spirit_nft_id,
+		)?;
+
+		Self::deposit_event(Event::SpiritClaimed {
+			owner: sender,
+			collection_id: spirit_collection_id,
+			nft_id: spirit_nft_id,
+		});
+
+		Ok(())
+	}
+
+	/// Mint an Origin of Shell NFT helper function that will take in the shell type, race and
+	/// career to mint the NFT to new owner
+	///
+	/// Parameters:
+	/// - `overlord`
+	/// - `sender`
+	/// - `origin_of_shell_type`
+	/// - `race`
+	/// - `career`
+	fn do_mint_origin_of_shell_nft(
+		overlord: T::AccountId,
+		sender: T::AccountId,
+		origin_of_shell_type: OriginOfShellType,
+		race: RaceType,
+		career: CareerType,
+		price: BalanceOf<T>,
+		check_owned_origin_of_shell: bool,
+	) -> DispatchResult {
+		// Has Spirit Collection been set
+		let spirit_collection_id = Self::get_spirit_collection_id()?;
+		ensure!(
+			Self::owns_nft_in_collection(&sender, spirit_collection_id),
+			Error::<T>::MustOwnSpiritToPurchase,
+		);
+		// Ensure origin_of_shell collection is set
+		let origin_of_shell_collection_id = Self::get_origin_of_shell_collection_id()?;
+		// If check_owned_origin_of_shell then check if account owns an origin of shell
+		if check_owned_origin_of_shell {
+			ensure!(
+				!Self::owns_nft_in_collection(&sender, origin_of_shell_collection_id),
+				Error::<T>::OriginOfShellAlreadyPurchased
+			);
+		}
+		// Get next NFT ID
+		let nft_id = pallet_rmrk_core::NextNftId::<T>::get(origin_of_shell_collection_id);
+		// Empty metadata
+		let metadata = Self::get_empty_metadata();
+		// Check if race and career types have mints left
+		Self::has_race_type_left(&origin_of_shell_type, &race)?;
+		// Transfer the amount for the rare Origin of Shell NFT then mint the origin_of_shell
+		<T as pallet::Config>::Currency::transfer(
+			&sender,
+			&overlord,
+			price,
+			ExistenceRequirement::KeepAlive,
+		)?;
+		// Mint Origin of Shell and transfer Origin of Shell to new owner
+		pallet_rmrk_core::Pallet::<T>::mint_nft(
+			Origin::<T>::Signed(overlord.clone()).into(),
+			sender.clone(),
+			origin_of_shell_collection_id,
+			None,
+			None,
+			metadata,
+		)?;
+		// Set Origin of Shell Type, Race and Career attributes for NFT
+		Self::set_nft_attributes(
+			origin_of_shell_collection_id,
+			nft_id,
+			origin_of_shell_type,
+			race,
+			career,
+		)?;
+		// Update storage
+		Self::decrement_race_type_left(origin_of_shell_type, race)?;
+		Self::increment_race_type(origin_of_shell_type, race)?;
+		Self::increment_career_type(career);
+
+		// Freeze NFT so it cannot be transferred
+		pallet_uniques::Pallet::<T>::freeze(
+			Origin::<T>::Signed(overlord).into(),
+			origin_of_shell_collection_id,
+			nft_id,
+		)?;
+
+		Self::deposit_event(Event::OriginOfShellMinted {
+			origin_of_shell_type,
+			collection_id: origin_of_shell_collection_id,
+			nft_id,
+			owner: sender,
+			race,
+			career,
+		});
+
+		Ok(())
+	}
+
+	/// Set the attributes for Origin of Shell or Shell NFT's type, race and career.
+	///
+	/// Parameters:
+	/// - `collection_id`: Collection id of the Origin of Shell or Shell NFT
+	/// - `nft_id`: NFT id of the Origin of Shell or Shell NFT
+	/// - `origin_of_shell_type`: Origin of Shell or Shell type for the NFT
+	/// - `race`: Race attribute to set for the Origin of Shell or Shell NFT
+	/// - `career`: Career attribute to set for the Origin of Shell or Shell NFT
+	pub(crate) fn set_nft_attributes(
+		collection_id: CollectionId,
+		nft_id: NftId,
+		origin_of_shell_type: OriginOfShellType,
+		race: RaceType,
+		career: CareerType,
+	) -> DispatchResult {
+		let overlord = Self::overlord()?;
+
+		let origin_of_shell_type_key: BoundedVec<u8, T::KeyLimit> =
+			Self::to_boundedvec_key("origin_of_shell_type")?;
+		let origin_of_shell_type_value = origin_of_shell_type
+			.encode()
+			.try_into()
+			.expect("[origin_of_shell_type] should not fail");
+
+		let race_key: BoundedVec<u8, T::KeyLimit> = Self::to_boundedvec_key("race")?;
+		let race_value = race.encode().try_into().expect("[race] should not fail");
+
+		let career_key = Self::to_boundedvec_key("career")?;
+		let career_value = career
+			.encode()
+			.try_into()
+			.expect("[career] should not fail");
+
+		// Set Origin of Shell Type
+		pallet_uniques::Pallet::<T>::set_attribute(
+			Origin::<T>::Signed(overlord.clone()).into(),
+			collection_id,
+			Some(nft_id),
+			origin_of_shell_type_key,
+			origin_of_shell_type_value,
+		)?;
+		// Set Race
+		pallet_uniques::Pallet::<T>::set_attribute(
+			Origin::<T>::Signed(overlord.clone()).into(),
+			collection_id,
+			Some(nft_id),
+			race_key,
+			race_value,
+		)?;
+		// Set Career
+		pallet_uniques::Pallet::<T>::set_attribute(
+			Origin::<T>::Signed(overlord).into(),
+			collection_id,
+			Some(nft_id),
+			career_key,
+			career_value,
+		)?;
+
+		Ok(())
+	}
+
+	/// Decrement CareerType count for the `career`
+	///
+	/// Parameters:
+	/// - `career`: The Career to increment count
+	fn decrement_career_type(career: CareerType) {
+		CareerTypeCount::<T>::mutate(career, |career_count| {
+			*career_count -= 1;
+			*career_count
+		});
+	}
+
+	/// Increment RaceType count for the `race`
+	///
+	/// Parameters:
+	/// - `origin_of_shell_type`: Origin of Shell type
+	/// - `race`: The Career to increment count
+	fn increment_race_type(
+		origin_of_shell_type: OriginOfShellType,
+		race: RaceType,
+	) -> DispatchResult {
+		OriginOfShellsInventory::<T>::try_mutate_exists(
+			origin_of_shell_type,
+			race,
+			|nft_sale_info| -> DispatchResult {
+				if let Some(nft_sale_info) = nft_sale_info {
+					nft_sale_info.race_count += 1;
+				}
+				Ok(())
+			},
+		)?;
+
+		Ok(())
+	}
+
+	/// Increment CareerType count for the `career`
+	///
+	/// Parameters:
+	/// - `career`: The Career to increment count
+	fn increment_career_type(career: CareerType) {
+		CareerTypeCount::<T>::mutate(career, |career_count| {
+			*career_count += 1;
+			*career_count
+		});
+	}
+
+	/// Decrement RaceType count for the `race`
+	///
+	/// Parameters:
+	/// - `race`: The Race to increment count
+	fn decrement_race_type_left(
+		origin_of_shell_type: OriginOfShellType,
+		race: RaceType,
+	) -> DispatchResult {
+		OriginOfShellsInventory::<T>::try_mutate_exists(
+			origin_of_shell_type,
+			race,
+			|nft_sale_info| -> DispatchResult {
+				if let Some(nft_sale_info) = nft_sale_info {
+					nft_sale_info.race_for_sale_count.saturating_sub(1);
+				}
+				Ok(())
+			},
+		)?;
+
+		Ok(())
+	}
+
+	/// Verify if the chosen Race has reached the max limit
+	///
+	/// Parameters:
+	/// - `race`: The Race to check
+	fn has_race_type_left(
+		origin_of_shell_type: &OriginOfShellType,
+		race: &RaceType,
+	) -> DispatchResult {
+		if let Some(nft_sale_info) = OriginOfShellsInventory::<T>::get(origin_of_shell_type, race) {
+			ensure!(
+				nft_sale_info.race_for_sale_count > 0,
+				Error::<T>::RaceMintMaxReached
+			);
+		} else {
+			return Err(Error::<T>::OriginOfShellInventoryCorrupted.into());
+		}
+
+		Ok(())
+	}
+
+	/// Helper function to get collection id origin of shell collection
+	fn get_origin_of_shell_collection_id() -> Result<CollectionId, Error<T>> {
+		let origin_of_shell_collection_id = OriginOfShellCollectionId::<T>::get()
+			.ok_or(Error::<T>::OriginOfShellCollectionNotSet)?;
+		Ok(origin_of_shell_collection_id)
+	}
+
+	/// Helper function to get collection id spirit collection
+	fn get_spirit_collection_id() -> Result<CollectionId, Error<T>> {
+		let spirit_collection_id =
+			SpiritCollectionId::<T>::get().ok_or(Error::<T>::SpiritCollectionNotSet)?;
+		Ok(spirit_collection_id)
+	}
+
+	/// Helper function to check if owner has a NFT within a collection
+	///
+	/// Parameters:
+	/// `sender`: reference to the account id to check
+	/// `collection_id`: Collection id to check if sender owns a NFT in the collection
+	/// `error`: Error type to throw if there is an error detected
+	pub fn owns_nft_in_collection(sender: &T::AccountId, collection_id: CollectionId) -> bool {
+		pallet_uniques::Pallet::<T>::owned_in_class(&collection_id, sender).count() > 0
+	}
+
+	pub fn to_boundedvec_key(name: &str) -> Result<BoundedVec<u8, T::KeyLimit>, Error<T>> {
+		name.as_bytes()
+			.to_vec()
+			.try_into()
+			.map_err(|_| Error::<T>::KeyTooLong)
+	}
+
+	/// Helper function to get empty metadata boundedvec
+	pub(crate) fn get_empty_metadata() -> BoundedVec<u8, T::StringLimit> {
+		Default::default()
+	}
+}

--- a/pallets/phala-world/src/tests.rs
+++ b/pallets/phala-world/src/tests.rs
@@ -1,0 +1,1356 @@
+#![cfg(test)]
+
+use super::*;
+
+use crate::mock::*;
+use codec::Encode;
+use frame_support::{assert_noop, assert_ok, error::BadOrigin, traits::Currency, BoundedVec};
+use sp_core::{crypto::AccountId32, sr25519, Pair};
+
+use crate::traits::{
+	primitives::*, CareerType, OriginOfShellType, OverlordMessage, Purpose, RaceType, StatusType,
+};
+use mock::{Call, Event as MockEvent, ExtBuilder, Origin, PWIncubation, PWNftSale, RmrkCore, Test};
+use rmrk_traits::primitives::*;
+
+/// Turns a string into a BoundedVec
+fn stb(s: &str) -> BoundedVec<u8, UniquesStringLimit> {
+	s.as_bytes().to_vec().try_into().unwrap()
+}
+
+/// Turns a string into a BoundedVec
+fn stbk(s: &str) -> BoundedVec<u8, KeyLimit> {
+	s.as_bytes().to_vec().try_into().unwrap()
+}
+
+/// Turns a string into a Vec
+fn stv(s: &str) -> Vec<u8> {
+	s.as_bytes().to_vec()
+}
+
+macro_rules! bvec {
+	($( $x:tt )*) => {
+		vec![$( $x )*].try_into().unwrap()
+	}
+}
+
+fn metadata_accounts(
+	mut alice_metadata: BoundedVec<u8, UniquesStringLimit>,
+	mut bob_metadata: BoundedVec<u8, UniquesStringLimit>,
+	mut charlie_metadata: BoundedVec<u8, UniquesStringLimit>,
+) {
+	alice_metadata = stb("I am ALICE");
+	bob_metadata = stb("I am BOB");
+	charlie_metadata = stb("I am CHARLIE");
+}
+
+fn mint_collection(account: AccountId32) {
+	// Mint Spirits collection
+	RmrkCore::create_collection(
+		Origin::signed(account),
+		bvec![0u8; 20],
+		Some(5),
+		bvec![0u8; 15],
+	);
+}
+
+fn mint_spirit(account: AccountId32, spirit_signature: Option<sr25519::Signature>) {
+	let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+	if let Some(spirit_signature) = spirit_signature {
+		let message = OverlordMessage {
+			account: account.clone(),
+			purpose: Purpose::RedeemSpirit,
+		};
+		let enc_msg = Encode::encode(&message);
+		let signature = overlord_pair.sign(&enc_msg);
+		assert_ok!(PWNftSale::redeem_spirit(Origin::signed(account), signature));
+	} else {
+		// Mint Spirit NFT
+		assert_ok!(PWNftSale::claim_spirit(Origin::signed(account)));
+	}
+}
+
+fn setup_config(enable_status_type: StatusType) {
+	// Set Overlord account
+	assert_ok!(PWNftSale::set_overlord(Origin::root(), OVERLORD));
+	let spirit_collection_id = RmrkCore::collection_index();
+	// Mint Spirits Collection
+	mint_collection(OVERLORD);
+	// Set Spirit Collection ID
+	assert_ok!(PWNftSale::set_spirit_collection_id(
+		Origin::signed(OVERLORD),
+		spirit_collection_id
+	));
+	let origin_of_shell_collection_id = RmrkCore::collection_index();
+	// Mint Origin of Shells Collection
+	mint_collection(OVERLORD);
+	// Set Origin of Shell Collection ID
+	assert_ok!(PWNftSale::set_origin_of_shell_collection_id(
+		Origin::signed(OVERLORD),
+		origin_of_shell_collection_id
+	));
+	// Initialize the Phala World Clock
+	assert_ok!(PWNftSale::initialize_world_clock(Origin::signed(OVERLORD)));
+	// Initialize Origin of Shell Inventory numbers
+	assert_ok!(PWNftSale::init_origin_of_shell_type_counts(Origin::signed(
+		OVERLORD
+	)));
+	match enable_status_type {
+		StatusType::ClaimSpirits => {
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::ClaimSpirits
+			));
+		}
+		StatusType::PurchaseRareOriginOfShells => {
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::ClaimSpirits
+			));
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::PurchaseRareOriginOfShells
+			));
+		}
+		StatusType::PurchasePrimeOriginOfShells => {
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::ClaimSpirits
+			));
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::PurchasePrimeOriginOfShells
+			));
+		}
+		StatusType::PreorderOriginOfShells => {
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::ClaimSpirits
+			));
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::PreorderOriginOfShells
+			));
+		}
+		StatusType::LastDayOfSale => {
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::ClaimSpirits
+			));
+			assert_ok!(PWNftSale::set_status_type(
+				Origin::signed(OVERLORD),
+				true,
+				StatusType::LastDayOfSale
+			));
+		}
+	}
+}
+
+#[test]
+fn claimed_spirit_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		// let overlord_pub = overlord_pair.public();
+		// Set Overlord and configuration then enable spirits to be claimed
+		setup_config(StatusType::ClaimSpirits);
+		let message = OverlordMessage {
+			account: BOB,
+			purpose: Purpose::RedeemSpirit,
+		};
+		// Sign BOB's Public Key and Metadata encoding with OVERLORD account
+		let claim = Encode::encode(&message);
+		let overlord_signature = overlord_pair.sign(&claim);
+		// Dispatch a redeem_spirit from BOB's account
+		assert_ok!(PWNftSale::redeem_spirit(
+			Origin::signed(BOB),
+			overlord_signature
+		));
+		// ALICE should be able to claim since she has minimum amount of PHA
+		assert_ok!(PWNftSale::claim_spirit(Origin::signed(ALICE)));
+	});
+}
+
+#[test]
+fn claimed_spirit_twice_fails() {
+	ExtBuilder::default().build(ALICE).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		//let overlord_pub = overlord_pair.public();
+		// Set Overlord and configuration then enable spirits to be claimed
+		setup_config(StatusType::ClaimSpirits);
+		//  Only root can set the Overlord Admin account
+		assert_noop!(
+			PWNftSale::set_overlord(Origin::signed(ALICE), BOB),
+			BadOrigin
+		);
+		// Enable spirits to be claimed
+		assert_noop!(
+			PWNftSale::set_status_type(Origin::signed(BOB), true, StatusType::ClaimSpirits),
+			pallet_pw_nft_sale::Error::<Test>::RequireOverlordAccount
+		);
+		// Dispatch a claim spirit from ALICE's account
+		assert_ok!(PWNftSale::claim_spirit(Origin::signed(ALICE)));
+		// Fail to dispatch a second claim spirit
+		assert_noop!(
+			PWNftSale::claim_spirit(Origin::signed(ALICE)),
+			pallet_pw_nft_sale::Error::<Test>::SpiritAlreadyClaimed
+		);
+	});
+}
+
+#[test]
+fn start_world_clock_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		// Set the Overlord Admin account
+		assert_ok!(PWNftSale::set_overlord(Origin::root(), OVERLORD));
+		// Initialize the Phala World Clock
+		assert_ok!(PWNftSale::initialize_world_clock(Origin::signed(OVERLORD)));
+	});
+}
+
+#[test]
+fn auto_increment_era_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		// Set Overlord admin as BOB
+		assert_ok!(PWNftSale::set_overlord(Origin::root(), BOB));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OverlordChanged {
+				old_overlord: Some(OVERLORD),
+				new_overlord: BOB,
+			},
+		));
+		// Initialize the Phala World Clock
+		assert_ok!(PWNftSale::initialize_world_clock(Origin::signed(BOB)));
+		// Check Zero Day is Some(1)
+		assert_eq!(PWNftSale::zero_day(), Some(INIT_TIMESTAMP_SECONDS));
+		// Go to block 7 that would increment the Era at Block 6
+		fast_forward_to(7);
+		// Check Era is 1
+		assert_eq!(PWNftSale::era(), 1);
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::NewEra {
+				time: 5 * BLOCK_TIME_SECONDS + INIT_TIMESTAMP_SECONDS,
+				era: 1,
+			},
+		));
+		fast_forward_to(16);
+		// Check Era is 1
+		assert_eq!(PWNftSale::era(), 3);
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::NewEra {
+				time: 15 * BLOCK_TIME_SECONDS + INIT_TIMESTAMP_SECONDS,
+				era: 3,
+			},
+		));
+	});
+}
+
+#[test]
+fn purchase_rare_origin_of_shell_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		// Set Overlord and configuration then enable purchase of rare origin of shells
+		setup_config(StatusType::PurchaseRareOriginOfShells);
+		let bob_claim = Encode::encode(&BOB);
+		let bob_overlord_signature = overlord_pair.sign(&bob_claim);
+		let charlie_claim = Encode::encode(&CHARLIE);
+		let charlie_overlord_signature = overlord_pair.sign(&charlie_claim);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, Some(bob_overlord_signature));
+		mint_spirit(CHARLIE, Some(charlie_overlord_signature));
+		// ALICE purchases Legendary Origin of Shell
+		assert_ok!(PWNftSale::buy_rare_origin_of_shell(
+			Origin::signed(ALICE),
+			OriginOfShellType::Legendary,
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
+				origin_of_shell_type: OriginOfShellType::Legendary,
+				collection_id: 1,
+				nft_id: 0,
+				owner: ALICE,
+				race: RaceType::AISpectre,
+				career: CareerType::HackerWizard,
+			},
+		));
+		// BOB tries to buy Legendary Origin of Shell but not enough funds
+		assert_noop!(
+			PWNftSale::buy_rare_origin_of_shell(
+				Origin::signed(BOB),
+				OriginOfShellType::Legendary,
+				RaceType::Cyborg,
+				CareerType::HardwareDruid,
+			),
+			pallet_balances::Error::<Test>::InsufficientBalance
+		);
+		// BOB purchases Magic Origin of Shell
+		assert_ok!(PWNftSale::buy_rare_origin_of_shell(
+			Origin::signed(BOB),
+			OriginOfShellType::Magic,
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
+				origin_of_shell_type: OriginOfShellType::Magic,
+				collection_id: 1,
+				nft_id: 1,
+				owner: BOB,
+				race: RaceType::Cyborg,
+				career: CareerType::HardwareDruid,
+			},
+		));
+		// CHARLIE tries to purchase Prime origin of shell and fails
+		assert_noop!(
+			PWNftSale::buy_rare_origin_of_shell(
+				Origin::signed(CHARLIE),
+				OriginOfShellType::Prime,
+				RaceType::Pandroid,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::InvalidPurchase
+		);
+		// CHARLIE purchases Magic Origin Of Shell
+		assert_ok!(PWNftSale::buy_rare_origin_of_shell(
+			Origin::signed(CHARLIE),
+			OriginOfShellType::Magic,
+			RaceType::Pandroid,
+			CareerType::HackerWizard,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
+				origin_of_shell_type: OriginOfShellType::Magic,
+				collection_id: 1,
+				nft_id: 2,
+				owner: CHARLIE,
+				race: RaceType::Pandroid,
+				career: CareerType::HackerWizard,
+			},
+		));
+		// Check Balances of ALICE and BOB
+		assert_eq!(Balances::total_balance(&ALICE), 19_000_000 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_000 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_000 * PHA);
+	});
+}
+
+#[test]
+fn purchase_prime_origin_of_shell_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		let bob_pair = sr25519::Pair::from_seed(b"09876543210987654321098765432109");
+		// let overlord_pub = overlord_pair.public();
+		// Set Overlord and configuration then enable spirits to be claimed
+		setup_config(StatusType::PurchasePrimeOriginOfShells);
+		// Sign BOB's Public Key and Metadata encoding with OVERLORD account
+		// Set metadata for buyers
+		let mut alice_metadata = BoundedVec::default();
+		let mut bob_metadata = BoundedVec::default();
+		let mut charlie_metadata = BoundedVec::default();
+		metadata_accounts(alice_metadata, bob_metadata.clone(), charlie_metadata);
+		let bob_message = OverlordMessage {
+			account: BOB,
+			purpose: Purpose::BuyPrimeOriginOfShells,
+		};
+		let bob_spirit_msg = OverlordMessage {
+			account: BOB,
+			purpose: Purpose::RedeemSpirit,
+		};
+		// Sign BOB's Public Key and Metadata encoding with OVERLORD account
+		let claim = Encode::encode(&bob_message);
+		let fake_claim = Encode::encode(&bob_spirit_msg);
+		let bob_overlord_signature = overlord_pair.sign(&claim);
+		let fake_signature = overlord_pair.sign(&fake_claim);
+		// BOB cannot purchase another Origin of Shell without Spirit NFT
+		assert_noop!(
+			PWNftSale::buy_prime_origin_of_shell(
+				Origin::signed(BOB),
+				bob_overlord_signature.clone(),
+				RaceType::AISpectre,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::MustOwnSpiritToPurchase
+		);
+		// BOB mints Spirit NFT
+		mint_spirit(BOB, None);
+		// BOB cannot use RedeemSpirit OverlordMessage to buy prime Origin of Shell
+		assert_noop!(
+			PWNftSale::buy_prime_origin_of_shell(
+				Origin::signed(BOB),
+				fake_signature,
+				RaceType::AISpectre,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::WhitelistVerificationFailed
+		);
+		// BOB purchases a Prime NFT
+		assert_ok!(PWNftSale::buy_prime_origin_of_shell(
+			Origin::signed(BOB),
+			bob_overlord_signature.clone(),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
+				origin_of_shell_type: OriginOfShellType::Prime,
+				collection_id: 1,
+				nft_id: 0,
+				owner: BOB,
+				race: RaceType::AISpectre,
+				career: CareerType::HackerWizard,
+			},
+		));
+		// BOB cannot purchase another Origin of Shell
+		assert_noop!(
+			PWNftSale::buy_prime_origin_of_shell(
+				Origin::signed(BOB),
+				bob_overlord_signature,
+				RaceType::AISpectre,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::OriginOfShellAlreadyPurchased
+		);
+	});
+}
+
+#[test]
+fn preorder_origin_of_shell_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// ALICE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: ALICE,
+				preorder_id: 1,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// CHARLIE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(CHARLIE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+	});
+}
+
+#[test]
+fn preorder_origin_of_shell_works_2() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// ALICE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: ALICE,
+				preorder_id: 1,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// CHARLIE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(CHARLIE),
+				RaceType::Pandroid,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+	});
+}
+
+#[test]
+fn mint_preorder_origin_of_shell_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// CHARLIE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(CHARLIE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: CHARLIE,
+				preorder_id: 1,
+			},
+		));
+		// ALICE preorders an origin of shell successfully
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		let preorders: Vec<PreorderId> = vec![0u32, 1u32, 2u32];
+		// Set ALICE & BOB has Chosen and CHARLIE as NotChosen
+		assert_ok!(PWNftSale::mint_chosen_preorders(
+			Origin::signed(OVERLORD),
+			preorders
+		));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::ChosenPreorderMinted {
+				preorder_id: 2u32,
+				owner: ALICE,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// ALICE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(ALICE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+		assert_ok!(PWNftSale::set_status_type(
+			Origin::signed(OVERLORD),
+			false,
+			StatusType::PreorderOriginOfShells
+		));
+		// Check Balances of ALICE, BOB, CHARLIE & OVERLORD
+		assert_eq!(Balances::total_balance(&ALICE), 19_999_990 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_990 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_990 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_034 * PHA);
+	});
+}
+
+#[test]
+fn claim_refund_preorder_origin_of_shell_works() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		let overlord_pair = sr25519::Pair::from_seed(b"28133080042813308004281330800428");
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// CHARLIE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(CHARLIE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: CHARLIE,
+				preorder_id: 1,
+			},
+		));
+		// ALICE preorders an origin of shell successfully
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		// Preorder status Vec
+		let preorders: Vec<PreorderId> = vec![0u32, 1u32, 2u32];
+		// Set ALICE & BOB has Chosen and CHARLIE as NotChosen
+		assert_ok!(PWNftSale::refund_not_chosen_preorders(
+			Origin::signed(OVERLORD),
+			preorders
+		));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::NotChosenPreorderRefunded {
+				preorder_id: 2u32,
+				owner: ALICE,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// ALICE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(ALICE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+		assert_ok!(PWNftSale::set_status_type(
+			Origin::signed(OVERLORD),
+			false,
+			StatusType::PreorderOriginOfShells
+		));
+		// Check Balances of ALICE, BOB, CHARLIE & OVERLORD
+		assert_eq!(Balances::total_balance(&ALICE), 20_000_000 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 15_000 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 150_000 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_004 * PHA);
+	});
+}
+
+#[test]
+fn can_initiate_incubation_process() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// CHARLIE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(CHARLIE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: CHARLIE,
+				preorder_id: 1,
+			},
+		));
+		// ALICE preorders an origin of shell successfully
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		let preorders: Vec<PreorderId> = vec![0u32, 1u32, 2u32];
+		// Set ALICE & BOB has Chosen and CHARLIE as NotChosen
+		assert_ok!(PWNftSale::mint_chosen_preorders(
+			Origin::signed(OVERLORD),
+			preorders
+		));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::ChosenPreorderMinted {
+				preorder_id: 2u32,
+				owner: ALICE,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// ALICE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(ALICE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+		assert_ok!(PWNftSale::set_status_type(
+			Origin::signed(OVERLORD),
+			false,
+			StatusType::PreorderOriginOfShells
+		));
+		// Check Balances of ALICE, BOB, CHARLIE & OVERLORD
+		assert_eq!(Balances::total_balance(&ALICE), 19_999_990 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_990 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_990 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_034 * PHA);
+		// ALICE cannot start incubation process before it is enabled
+		assert_noop!(
+			PWIncubation::start_incubation(Origin::signed(ALICE), 1u32, 2u32),
+			pallet_pw_incubation::Error::<Test>::StartIncubationNotAvailable
+		);
+		// Set CanStartIncubationStatus to true
+		assert_ok!(PWIncubation::set_can_start_incubation_status(
+			Origin::signed(OVERLORD),
+			true
+		));
+		let now = INIT_TIMESTAMP_SECONDS;
+		let official_hatch_time = now + INCUBATION_DURATION_SEC;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::CanStartIncubationStatusChanged {
+				status: true,
+				start_time: now,
+				official_hatch_time,
+			},
+		));
+		// ALICE initiates incubation process
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(ALICE),
+			1u32,
+			2u32
+		));
+		let alice_now = INIT_TIMESTAMP_SECONDS;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				owner: ALICE,
+				start_time: alice_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		// BOB initiates during next block
+		fast_forward_to(2);
+		let bob_now = 2 * BLOCK_TIME_SECONDS + INIT_TIMESTAMP_SECONDS;
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(BOB),
+			1u32,
+			0u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 0u32,
+				owner: BOB,
+				start_time: bob_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		// CHARLIE fails if trying to start incubation of non-owned Origin of Shell
+		assert_noop!(
+			PWIncubation::start_incubation(Origin::signed(CHARLIE), 1u32, 0u32),
+			pallet_pw_incubation::Error::<Test>::NotOwner
+		);
+	});
+}
+
+#[test]
+fn can_update_incubation_hatch_time() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// CHARLIE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(CHARLIE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: CHARLIE,
+				preorder_id: 1,
+			},
+		));
+		// ALICE preorders an origin of shell successfully
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		let preorders: Vec<PreorderId> = vec![0u32, 1u32, 2u32];
+		// Set ALICE & BOB has Chosen and CHARLIE as NotChosen
+		assert_ok!(PWNftSale::mint_chosen_preorders(
+			Origin::signed(OVERLORD),
+			preorders
+		));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::ChosenPreorderMinted {
+				preorder_id: 2u32,
+				owner: ALICE,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// ALICE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(ALICE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+		assert_ok!(PWNftSale::set_status_type(
+			Origin::signed(OVERLORD),
+			false,
+			StatusType::PreorderOriginOfShells
+		));
+		// Check Balances of ALICE, BOB, CHARLIE & OVERLORD
+		assert_eq!(Balances::total_balance(&ALICE), 19_999_990 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_990 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_990 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_034 * PHA);
+		assert_ok!(PWIncubation::set_can_start_incubation_status(
+			Origin::signed(OVERLORD),
+			true
+		));
+		let now = INIT_TIMESTAMP_SECONDS;
+		let official_hatch_time = now + INCUBATION_DURATION_SEC;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::CanStartIncubationStatusChanged {
+				status: true,
+				start_time: now,
+				official_hatch_time,
+			},
+		));
+		// ALICE initiates incubation process
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(ALICE),
+			1u32,
+			2u32
+		));
+		let alice_now = INIT_TIMESTAMP_SECONDS;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				owner: ALICE,
+				start_time: alice_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		// Update ALICE hatch time
+		let update_hatch_time_vec = vec![((1u32, 2u32), 10)];
+		assert_ok!(PWIncubation::update_incubation_time(
+			Origin::signed(OVERLORD),
+			update_hatch_time_vec
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::HatchTimeUpdated {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				old_hatch_time: official_hatch_time,
+				new_hatch_time: official_hatch_time - 10,
+			},
+		));
+	});
+}
+
+#[test]
+fn can_send_food_to_origin_of_shell() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// CHARLIE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(CHARLIE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: CHARLIE,
+				preorder_id: 1,
+			},
+		));
+		// ALICE preorders an origin of shell successfully
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		let preorders: Vec<PreorderId> = vec![0u32, 1u32, 2u32];
+		// Set ALICE & BOB has Chosen and CHARLIE as NotChosen
+		assert_ok!(PWNftSale::mint_chosen_preorders(
+			Origin::signed(OVERLORD),
+			preorders
+		));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::ChosenPreorderMinted {
+				preorder_id: 2u32,
+				owner: ALICE,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// ALICE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(ALICE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+		assert_ok!(PWNftSale::set_status_type(
+			Origin::signed(OVERLORD),
+			false,
+			StatusType::PreorderOriginOfShells
+		));
+		// Check Balances of ALICE, BOB, CHARLIE & OVERLORD
+		assert_eq!(Balances::total_balance(&ALICE), 19_999_990 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_990 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_990 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_034 * PHA);
+		assert_ok!(PWIncubation::set_can_start_incubation_status(
+			Origin::signed(OVERLORD),
+			true
+		));
+		let now = INIT_TIMESTAMP_SECONDS;
+		let official_hatch_time = now + INCUBATION_DURATION_SEC;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::CanStartIncubationStatusChanged {
+				status: true,
+				start_time: now,
+				official_hatch_time,
+			},
+		));
+		// ALICE cannot transfer her Origin of Shell to BOB
+		assert_noop!(
+			RmrkCore::send(
+				Origin::signed(ALICE),
+				1u32,
+				2u32,
+				rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(BOB)
+			),
+			pallet_uniques::Error::<Test>::Frozen
+		);
+		// ALICE initiates incubation process
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(ALICE),
+			1u32,
+			2u32
+		));
+		let alice_now = INIT_TIMESTAMP_SECONDS;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				owner: ALICE,
+				start_time: alice_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		// Update ALICE hatch time
+		let update_hatch_time_vec = vec![((1u32, 2u32), 10)];
+		assert_ok!(PWIncubation::update_incubation_time(
+			Origin::signed(OVERLORD),
+			update_hatch_time_vec
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::HatchTimeUpdated {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				old_hatch_time: official_hatch_time,
+				new_hatch_time: official_hatch_time - 10,
+			},
+		));
+		// CHARLIE feeds ALICE's Origin of Shell Twice and fails on the third
+		assert_ok!(PWIncubation::feed_origin_of_shell(
+			Origin::signed(CHARLIE),
+			1u32,
+			2u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::OriginOfShellReceivedFood {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				sender: CHARLIE,
+			},
+		));
+		assert_ok!(PWIncubation::feed_origin_of_shell(
+			Origin::signed(CHARLIE),
+			1u32,
+			2u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::OriginOfShellReceivedFood {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				sender: CHARLIE,
+			},
+		));
+		assert_noop!(
+			PWIncubation::feed_origin_of_shell(Origin::signed(CHARLIE), 1u32, 2u32),
+			pallet_pw_incubation::Error::<Test>::AlreadySentFoodTwice
+		);
+		// CHARLIE can feed now that a new Era has started
+		fast_forward_to(7);
+		let bob_now = 7 * BLOCK_TIME_SECONDS + INIT_TIMESTAMP_SECONDS;
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(BOB),
+			1u32,
+			0u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 0u32,
+				owner: BOB,
+				start_time: bob_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		assert_ok!(PWIncubation::feed_origin_of_shell(
+			Origin::signed(CHARLIE),
+			1u32,
+			0u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::OriginOfShellReceivedFood {
+				collection_id: 1u32,
+				nft_id: 0u32,
+				sender: CHARLIE,
+			},
+		));
+		// OVERLORD cannot send food bc they do not own an Origin of Shell
+		assert_noop!(
+			PWIncubation::feed_origin_of_shell(Origin::signed(OVERLORD), 1u32, 0u32),
+			pallet_pw_incubation::Error::<Test>::CannotSendFoodToOriginOfShell
+		);
+	});
+}
+
+#[test]
+fn can_hatch_origin_of_shell() {
+	ExtBuilder::default().build(OVERLORD).execute_with(|| {
+		// Set Overlord and configuration then enable preorder origin of shells
+		setup_config(StatusType::PreorderOriginOfShells);
+		mint_spirit(ALICE, None);
+		mint_spirit(BOB, None);
+		mint_spirit(CHARLIE, None);
+		// BOB preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(BOB),
+			RaceType::Cyborg,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: BOB,
+				preorder_id: 0,
+			},
+		));
+		// CHARLIE preorders an origin of shell
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(CHARLIE),
+			RaceType::Pandroid,
+			CareerType::HardwareDruid,
+		));
+		// Check if event triggered
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::OriginOfShellPreordered {
+				owner: CHARLIE,
+				preorder_id: 1,
+			},
+		));
+		// ALICE preorders an origin of shell successfully
+		assert_ok!(PWNftSale::preorder_origin_of_shell(
+			Origin::signed(ALICE),
+			RaceType::AISpectre,
+			CareerType::HackerWizard,
+		));
+		let preorders: Vec<PreorderId> = vec![0u32, 1u32, 2u32];
+		// Set ALICE & BOB has Chosen and CHARLIE as NotChosen
+		assert_ok!(PWNftSale::mint_chosen_preorders(
+			Origin::signed(OVERLORD),
+			preorders
+		));
+		System::assert_last_event(MockEvent::PWNftSale(
+			crate::pallet_pw_nft_sale::Event::ChosenPreorderMinted {
+				preorder_id: 2u32,
+				owner: ALICE,
+			},
+		));
+		// Reassign PreorderIndex to max value
+		pallet_pw_nft_sale::PreorderIndex::<Test>::mutate(|id| *id = PreorderId::max_value());
+		// ALICE preorders an origin of shell but max value is reached
+		assert_noop!(
+			PWNftSale::preorder_origin_of_shell(
+				Origin::signed(ALICE),
+				RaceType::Cyborg,
+				CareerType::HackerWizard,
+			),
+			pallet_pw_nft_sale::Error::<Test>::NoAvailablePreorderId
+		);
+		assert_ok!(PWNftSale::set_status_type(
+			Origin::signed(OVERLORD),
+			false,
+			StatusType::PreorderOriginOfShells
+		));
+		// Check Balances of ALICE, BOB, CHARLIE & OVERLORD
+		assert_eq!(Balances::total_balance(&ALICE), 19_999_990 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_990 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_990 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_034 * PHA);
+		assert_ok!(PWIncubation::set_can_start_incubation_status(
+			Origin::signed(OVERLORD),
+			true
+		));
+		let now = INIT_TIMESTAMP_SECONDS;
+		let official_hatch_time = now + INCUBATION_DURATION_SEC;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::CanStartIncubationStatusChanged {
+				status: true,
+				start_time: now,
+				official_hatch_time,
+			},
+		));
+		// ALICE initiates incubation process
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(ALICE),
+			1u32,
+			2u32
+		));
+		let alice_now = INIT_TIMESTAMP_SECONDS;
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				owner: ALICE,
+				start_time: alice_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		// Update ALICE hatch time
+		let update_hatch_time_vec = vec![((1u32, 2u32), 10)];
+		assert_ok!(PWIncubation::update_incubation_time(
+			Origin::signed(OVERLORD),
+			update_hatch_time_vec
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::HatchTimeUpdated {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				old_hatch_time: official_hatch_time,
+				new_hatch_time: official_hatch_time - 10,
+			},
+		));
+		// CHARLIE feeds ALICE's Origin of Shell Twice and fails on the third
+		assert_ok!(PWIncubation::feed_origin_of_shell(
+			Origin::signed(CHARLIE),
+			1u32,
+			2u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::OriginOfShellReceivedFood {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				sender: CHARLIE,
+			},
+		));
+		assert_ok!(PWIncubation::feed_origin_of_shell(
+			Origin::signed(CHARLIE),
+			1u32,
+			2u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::OriginOfShellReceivedFood {
+				collection_id: 1u32,
+				nft_id: 2u32,
+				sender: CHARLIE,
+			},
+		));
+		assert_noop!(
+			PWIncubation::feed_origin_of_shell(Origin::signed(CHARLIE), 1u32, 2u32),
+			pallet_pw_incubation::Error::<Test>::AlreadySentFoodTwice
+		);
+		// CHARLIE cannot send food to BOB since he hasn't started incubation process
+		assert_noop!(
+			PWIncubation::feed_origin_of_shell(Origin::signed(CHARLIE), 1u32, 0u32),
+			pallet_pw_incubation::Error::<Test>::NoHatchTimeDetected
+		);
+		// CHARLIE can feed now that a new Era has started
+		fast_forward_to(7);
+		let bob_now = 7 * BLOCK_TIME_SECONDS + INIT_TIMESTAMP_SECONDS;
+		assert_ok!(PWIncubation::start_incubation(
+			Origin::signed(BOB),
+			1u32,
+			0u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::StartedIncubation {
+				collection_id: 1u32,
+				nft_id: 0u32,
+				owner: BOB,
+				start_time: bob_now,
+				hatch_time: official_hatch_time,
+			},
+		));
+		// CHARLIE can feed BOB's Origin of Shell now
+		assert_ok!(PWIncubation::feed_origin_of_shell(
+			Origin::signed(CHARLIE),
+			1u32,
+			0u32
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::OriginOfShellReceivedFood {
+				collection_id: 1u32,
+				nft_id: 0u32,
+				sender: CHARLIE,
+			},
+		));
+		// OVERLORD cannot send food bc they do not own an Origin of Shell
+		assert_noop!(
+			PWIncubation::feed_origin_of_shell(Origin::signed(OVERLORD), 1u32, 2u32),
+			pallet_pw_incubation::Error::<Test>::CannotSendFoodToOriginOfShell
+		);
+		// Update ALICE hatch time
+		let update_hatch_time_vec = vec![((1u32, 2u32), now - 10)];
+		assert_ok!(PWIncubation::update_incubation_time(
+			Origin::signed(OVERLORD),
+			update_hatch_time_vec
+		));
+		let shell_collection_id = RmrkCore::collection_index();
+		// Mint Shell Collection
+		mint_collection(OVERLORD);
+		assert_ok!(PWIncubation::set_shell_collection_id(
+			Origin::signed(OVERLORD),
+			shell_collection_id
+		));
+		fast_forward_to(600);
+		// ALICE can hatch origin of shell from OVERLORD admin call
+		assert_ok!(PWIncubation::hatch_origin_of_shell(
+			Origin::signed(OVERLORD),
+			1u32,
+			2u32,
+			bvec![0u8; 15]
+		));
+		System::assert_last_event(MockEvent::PWIncubation(
+			crate::pallet_pw_incubation::Event::ShellAwakened {
+				collection_id: 2u32,
+				nft_id: 0u32,
+				owner: ALICE,
+			},
+		));
+		// BOB cannot trade his NFT
+		assert_noop!(
+			RmrkCore::send(
+				Origin::signed(BOB),
+				1u32,
+				0u32,
+				rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(CHARLIE)
+			),
+			pallet_uniques::Error::<Test>::Frozen
+		);
+		assert_eq!(Balances::total_balance(&ALICE), 19_999_990 * PHA);
+		assert_eq!(Balances::total_balance(&BOB), 14_990 * PHA);
+		assert_eq!(Balances::total_balance(&CHARLIE), 149_990 * PHA);
+		assert_eq!(Balances::total_balance(&OVERLORD), 2_813_308_034 * PHA);
+	});
+}

--- a/pallets/phala-world/src/tests.rs
+++ b/pallets/phala-world/src/tests.rs
@@ -90,6 +90,17 @@ fn setup_config(enable_status_type: StatusType) {
 		Origin::signed(OVERLORD),
 		origin_of_shell_collection_id
 	));
+	let origin_of_shells_metadata = vec![
+		(RaceType::Pandroid, bvec![0u8; 1]),
+		(RaceType::Cyborg, bvec![0u8; 2]),
+		(RaceType::AISpectre, bvec![0u8; 3]),
+		(RaceType::XGene, bvec![0u8; 4]),
+	];
+	// Set Metadata for each Race's Origin of Shell
+	assert_ok!(PWNftSale::set_origin_of_shells_metadata(
+		Origin::signed(OVERLORD),
+		origin_of_shells_metadata
+	));
 	// Initialize the Phala World Clock
 	assert_ok!(PWNftSale::initialize_world_clock(Origin::signed(OVERLORD)));
 	// Initialize Origin of Shell Inventory numbers

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -81,6 +81,15 @@ pub struct PreorderInfo<AccountId, BoundedString> {
 	pub metadata: BoundedString,
 }
 
+/// NFT sale types
+#[derive(Encode, Decode, Debug, Clone, Copy, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum NftSaleType {
+	ForSale,
+	Giveaway,
+	Reserved,
+}
+
 /// NftSaleInfo is used as the value in the StorageDoubleMap that takes key1 as the
 /// OriginOfShellType and key2 as the RaceType
 #[derive(Encode, Decode, Eq, PartialEq, Clone, Copy, RuntimeDebug, TypeInfo, MaxEncodedLen)]

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -1,0 +1,105 @@
+use codec::{Decode, Encode};
+use frame_support::pallet_prelude::*;
+use primitives::*;
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use sp_runtime::RuntimeDebug;
+use sp_std::cmp::Eq;
+
+// Primitives
+pub mod primitives {
+	pub type PreorderId = u32;
+	pub type EraId = u64;
+}
+
+/// Status types for different NFT Sale phases
+#[derive(Encode, Decode, Debug, Clone, PartialEq, TypeInfo)]
+pub enum StatusType {
+	ClaimSpirits,
+	PurchaseRareOriginOfShells,
+	PurchasePrimeOriginOfShells,
+	PreorderOriginOfShells,
+	LastDayOfSale,
+}
+
+/// Purpose of an OverlordMessage
+#[derive(Encode, Decode, Clone, Copy, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum Purpose {
+	RedeemSpirit,
+	BuyPrimeOriginOfShells,
+}
+
+/// Overlord message with a purpose that will be signed by Overlord account
+#[derive(Encode, Decode, Clone, Debug, PartialEq, TypeInfo)]
+pub struct OverlordMessage<AccountId> {
+	pub account: AccountId,
+	pub purpose: Purpose,
+}
+
+/// Origin of Shell Types of Prime, Magic & Legendary
+#[derive(Encode, Decode, Clone, Copy, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum OriginOfShellType {
+	Prime,
+	Magic,
+	Legendary,
+}
+
+/// Race types
+#[derive(Encode, Decode, Debug, Clone, Copy, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum RaceType {
+	Cyborg,
+	AISpectre,
+	XGene,
+	Pandroid,
+}
+
+/// Career types
+#[derive(Encode, Decode, Debug, Clone, Copy, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum CareerType {
+	HackerWizard,
+	HardwareDruid,
+	RoboWarrior,
+	TradeNegotiator,
+	Web3Monk,
+}
+
+/// Preorder info for Non-Whitelist preorders
+#[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct PreorderInfo<AccountId, BoundedString> {
+	/// Account owner of the Origin of Shell preorder
+	pub owner: AccountId,
+	/// Race type of the preorder
+	pub race: RaceType,
+	/// Career type of the preorder
+	pub career: CareerType,
+	/// Metadata of the owner
+	pub metadata: BoundedString,
+}
+
+/// NftSaleInfo is used as the value in the StorageDoubleMap that takes key1 as the
+/// OriginOfShellType and key2 as the RaceType
+#[derive(Encode, Decode, Eq, PartialEq, Clone, Copy, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+pub struct NftSaleInfo {
+	/// Number of Race Type count
+	pub race_count: u32,
+	/// Number of races left to sell
+	pub race_for_sale_count: u32,
+	/// Number of giveaway races left
+	pub race_giveaway_count: u32,
+	/// Number of reserved races left
+	pub race_reserved_count: u32,
+}
+
+/// Incubation Food info
+#[derive(Encode, Decode, Clone, RuntimeDebug, TypeInfo)]
+pub struct FoodInfo<BoundedOriginOfShellsFed> {
+	/// Era that an account last fed food to another Origin of Shell.
+	pub era: EraId,
+	/// A BoundedVec of (CollectionId, NftId)
+	pub origin_of_shells_fed: BoundedOriginOfShellsFed,
+}

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -89,6 +89,7 @@ pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release
 pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
@@ -96,6 +97,7 @@ pallet-parachain-info = { path = "../../pallets/parachain-info", default-feature
 phala-pallets = { path = "../../pallets/phala", default-features = false }
 pallet-mq-runtime-api = { path = "../../pallets/phala/mq-runtime-api", default-features = false }
 subbridge-pallets = { path = "../../pallets/subbridge", default-features = false }
+pallet-phala-world = { path = "../../pallets/phala-world", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
@@ -206,6 +208,7 @@ std = [
 	"pallet-rmrk-core/std",
 	"pallet-rmrk-market/std",
 	"pallet-rmrk-equip/std",
+	"pallet-phala-world/std",
 ]
 
 try-runtime = [

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -137,6 +137,7 @@ runtime-benchmarks = [
 	"pallet-xcm/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"subbridge-pallets/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 ]
 std = [
 	"codec/std",

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -85,6 +85,11 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "releas
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 
+# RMRK dependencies
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
 pallet-parachain-info = { path = "../../pallets/parachain-info", default-features = false }
@@ -198,6 +203,9 @@ std = [
 	"pallet-mq-runtime-api/std",
 	"assets-registry/std",
 	"subbridge-pallets/std",
+	"pallet-rmrk-core/std",
+	"pallet-rmrk-market/std",
+	"pallet-rmrk-equip/std",
 ]
 
 try-runtime = [

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -63,6 +63,7 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 
 # Cumulus dependencies
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.22", default-features = false }
@@ -124,6 +125,7 @@ runtime-benchmarks = [
 	"pallet-tips/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 	"phala-pallets/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
@@ -191,6 +193,7 @@ std = [
 	"pallet-assets/std",
 	"pallet-preimage/std",
 	"pallet-parachain-info/std",
+	"pallet-uniques/std",
 	"phala-pallets/std",
 	"pallet-mq-runtime-api/std",
 	"assets-registry/std",
@@ -225,5 +228,6 @@ try-runtime = [
 	"pallet-elections-phragmen/try-runtime",
 	"pallet-tips/try-runtime",
 	"pallet-assets/try-runtime",
+	"pallet-uniques/try-runtime",
 	"phala-pallets/try-runtime",
 ]

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -300,12 +300,23 @@ impl Contains<Call> for BaseCallFilter {
 
         if let Call::Uniques(uniques_method) = call {
             return match uniques_method {
-                pallet_uniques::Call::freeze { .. }
-                | pallet_uniques::Call::thaw { .. }
-                | pallet_uniques::Call::set_team { .. }
-                | pallet_uniques::Call::set_attribute { .. }
-                | pallet_uniques::Call::clear_attribute { .. }
-                | pallet_uniques::Call::set_accept_ownership { .. }
+                pallet_uniques::Call::approve_transfer { .. }
+                | pallet_uniques::Call::burn { .. }
+                | pallet_uniques::Call::cancel_approval { .. }
+                | pallet_uniques::Call::clear_class_metadata { .. }
+                | pallet_uniques::Call::clear_metadata { .. }
+                | pallet_uniques::Call::create { .. }
+                | pallet_uniques::Call::destroy { .. }
+                | pallet_uniques::Call::force_asset_status { .. }
+                | pallet_uniques::Call::force_create { .. }
+                | pallet_uniques::Call::freeze_class { .. }
+                | pallet_uniques::Call::mint { .. }
+                | pallet_uniques::Call::redeposit { .. }
+                | pallet_uniques::Call::set_class_metadata { .. }
+                | pallet_uniques::Call::set_metadata { .. }
+                | pallet_uniques::Call::thaw_class { .. }
+                | pallet_uniques::Call::transfer { .. }
+                | pallet_uniques::Call::transfer_ownership { .. }
                 | pallet_uniques::Call::__Ignore { .. } => false,
                 _ => true,
             };

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -259,12 +259,17 @@ construct_runtime! {
         PhalaStakePool: pallet_stakepool::{Pallet, Call, Event<T>, Storage} = 88,
         Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 89,
         AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 90,
-        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 91,
 
         // `sudo` has been removed on production
         // Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
         // `OTT` has been removed, the index should be kept
         // PhalaOneshotTransfer: pallet_ott::{Pallet, Call, Event<T>, Storage} = 100,
+
+        // Phala World
+        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 101,
+        RmrkCore: pallet_rmrk_core::{Pallet, Call, Storage, Event<T>} = 102,
+        RmrkEquip: pallet_rmrk_equip::{Pallet, Storage, Event<T>} = 103,
+        RmrkMarket: pallet_rmrk_market::{Pallet, Call, Storage, Event<T>} = 104,
     }
 }
 
@@ -322,6 +327,16 @@ impl Contains<Call> for BaseCallFilter {
             };
         }
 
+        if let Call::RmrkCore(rmrk_core_method) = call {
+            return match rmrk_core_method {
+                pallet_rmrk_core::Call::mint_nft { .. }
+                | pallet_rmrk_core::Call::send { .. }
+                | pallet_rmrk_core::Call::change_collection_issuer { .. }
+                | pallet_rmrk_core::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+
         matches!(
             call,
             // System
@@ -348,7 +363,9 @@ impl Contains<Call> for BaseCallFilter {
             Call::Lottery { .. } | Call::Tips { .. } |
             // Phala
             Call::PhalaMq { .. } | Call::PhalaRegistry { .. } |
-            Call::PhalaMining { .. } | Call::PhalaStakePool { .. }
+            Call::PhalaMining { .. } | Call::PhalaStakePool { .. } |
+            // Phala World
+            Call::RmrkMarket { .. }
         )
     }
 }
@@ -825,6 +842,46 @@ impl pallet_uniques::Config for Runtime {
     #[cfg(feature = "runtime-benchmarks")]
     type Helper = ();
     type WeightInfo = pallet_uniques::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+    pub const MaxRecursions: u32 = 10;
+    pub const ResourceSymbolLimit: u32 = 10;
+    pub const PartsLimit: u32 = 3;
+    pub const MaxPriorities: u32 = 3;
+    pub const CollectionSymbolLimit: u32 = 100;
+}
+
+impl pallet_rmrk_core::Config for Runtime {
+    type Event = Event;
+    type ProtocolOrigin = EnsureRoot<AccountId>;
+    type MaxRecursions = MaxRecursions;
+    type ResourceSymbolLimit = ResourceSymbolLimit;
+    type PartsLimit = PartsLimit;
+    type MaxPriorities = MaxPriorities;
+    type CollectionSymbolLimit = CollectionSymbolLimit;
+}
+
+parameter_types! {
+    pub const MaxPropertiesPerTheme: u32 = 100;
+    pub const MaxCollectionsEquippablePerPart: u32 = 100;
+}
+
+impl pallet_rmrk_equip::Config for Runtime {
+    type Event = Event;
+    type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
+    type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
+}
+
+parameter_types! {
+    pub const MinimumOfferAmount: Balance = DOLLARS / 10_000;
+}
+
+impl pallet_rmrk_market::Config for Runtime {
+    type Event = Event;
+    type ProtocolOrigin = EnsureRoot<AccountId>;
+    type Currency = Balances;
+    type MinimumOfferAmount = MinimumOfferAmount;
 }
 
 impl pallet_parachain_info::Config for Runtime {}

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -900,7 +900,7 @@ parameter_types! {
 }
 impl pallet_pw_nft_sale::Config for Runtime {
     type Event = Event;
-    type OverlordOrigin = EnsureRootOrHalfCouncil;
+    type GovernanceOrigin = EnsureRootOrHalfCouncil;
     type Currency = Balances;
     type Time = pallet_timestamp::Pallet<Runtime>;
     type SecondsPerEra = SecondsPerEra;

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -98,6 +98,7 @@ use xcm_executor::{Config, XcmExecutor};
 pub use parachains_common::Index;
 pub use parachains_common::*;
 
+pub use pallet_phala_world::{pallet_pw_incubation, pallet_pw_nft_sale};
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
 pub use subbridge_pallets::{
     chainbridge, fungible_adapter::XTransferAdapter, helper, xcmbridge, xtransfer,
@@ -270,6 +271,8 @@ construct_runtime! {
         RmrkCore: pallet_rmrk_core::{Pallet, Call, Storage, Event<T>} = 102,
         RmrkEquip: pallet_rmrk_equip::{Pallet, Storage, Event<T>} = 103,
         RmrkMarket: pallet_rmrk_market::{Pallet, Call, Storage, Event<T>} = 104,
+        PWNftSale: pallet_pw_nft_sale::{Pallet, Call, Storage, Event<T>} = 105,
+        PWIncubation: pallet_pw_incubation::{Pallet, Call, Storage, Event<T>} = 106,
     }
 }
 
@@ -365,7 +368,7 @@ impl Contains<Call> for BaseCallFilter {
             Call::PhalaMq { .. } | Call::PhalaRegistry { .. } |
             Call::PhalaMining { .. } | Call::PhalaStakePool { .. } |
             // Phala World
-            Call::RmrkMarket { .. }
+            Call::RmrkMarket { .. } | Call::PWNftSale { .. } | Call::PWIncubation { .. }
         )
     }
 }
@@ -882,6 +885,37 @@ impl pallet_rmrk_market::Config for Runtime {
     type ProtocolOrigin = EnsureRoot<AccountId>;
     type Currency = Balances;
     type MinimumOfferAmount = MinimumOfferAmount;
+}
+
+parameter_types! {
+    pub const SecondsPerEra: u64 = 86_400;
+    pub const MinBalanceToClaimSpirit: Balance = 10 * DOLLARS;
+    pub const LegendaryOriginOfShellPrice: Balance = 15_000 * DOLLARS;
+    pub const MagicOriginOfShellPrice: Balance = 10_000 * DOLLARS;
+    pub const PrimeOriginOfShellPrice: Balance = 500 * DOLLARS;
+    pub const IterLimit: u32 = 1_000;
+    pub const FoodPerEra: u32 = 5;
+    pub const MaxFoodFeedSelf: u8 = 2;
+    pub const IncubationDurationSec: u64 = 1_209_600;
+}
+impl pallet_pw_nft_sale::Config for Runtime {
+    type Event = Event;
+    type OverlordOrigin = EnsureRootOrHalfCouncil;
+    type Currency = Balances;
+    type Time = pallet_timestamp::Pallet<Runtime>;
+    type SecondsPerEra = SecondsPerEra;
+    type MinBalanceToClaimSpirit = MinBalanceToClaimSpirit;
+    type LegendaryOriginOfShellPrice = LegendaryOriginOfShellPrice;
+    type MagicOriginOfShellPrice = MagicOriginOfShellPrice;
+    type PrimeOriginOfShellPrice = PrimeOriginOfShellPrice;
+    type IterLimit = IterLimit;
+}
+
+impl pallet_pw_incubation::Config for Runtime {
+    type Event = Event;
+    type FoodPerEra = FoodPerEra;
+    type MaxFoodFeedSelf = MaxFoodFeedSelf;
+    type IncubationDurationSec = IncubationDurationSec;
 }
 
 impl pallet_parachain_info::Config for Runtime {}

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -85,6 +85,11 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "releas
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 
+# RMRK dependencies
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
 pallet-parachain-info = { path = "../../pallets/parachain-info", default-features = false }
@@ -199,6 +204,9 @@ std = [
 	"pallet-mq-runtime-api/std",
 	"assets-registry/std",
 	"subbridge-pallets/std",
+	"pallet-rmrk-core/std",
+	"pallet-rmrk-market/std",
+	"pallet-rmrk-equip/std",
 ]
 
 try-runtime = [

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -89,6 +89,7 @@ pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release
 pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
@@ -96,6 +97,7 @@ pallet-parachain-info = { path = "../../pallets/parachain-info", default-feature
 phala-pallets = { path = "../../pallets/phala", default-features = false }
 pallet-mq-runtime-api = { path = "../../pallets/phala/mq-runtime-api", default-features = false }
 subbridge-pallets = { path = "../../pallets/subbridge", default-features = false }
+pallet-phala-world = { path = "../../pallets/phala-world", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
@@ -207,6 +209,7 @@ std = [
 	"pallet-rmrk-core/std",
 	"pallet-rmrk-market/std",
 	"pallet-rmrk-equip/std",
+	"pallet-phala-world/std",
 ]
 
 try-runtime = [

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -137,6 +137,7 @@ runtime-benchmarks = [
 	"pallet-xcm/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"subbridge-pallets/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 ]
 std = [
 	"codec/std",

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -63,6 +63,7 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 
 # Cumulus dependencies
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.22", default-features = false }
@@ -124,6 +125,7 @@ runtime-benchmarks = [
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-tips/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 	"phala-pallets/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
@@ -192,6 +194,7 @@ std = [
 	"pallet-tips/std",
 	"pallet-assets/std",
 	"pallet-parachain-info/std",
+	"pallet-uniques/std",
 	"phala-pallets/std",
 	"pallet-mq-runtime-api/std",
 	"assets-registry/std",
@@ -227,5 +230,6 @@ try-runtime = [
 	"pallet-elections-phragmen/try-runtime",
 	"pallet-tips/try-runtime",
 	"pallet-assets/try-runtime",
+	"pallet-uniques/try-runtime",
 	"phala-pallets/try-runtime",
 ]

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -98,6 +98,7 @@ use xcm_executor::{Config, XcmExecutor};
 pub use parachains_common::Index;
 pub use parachains_common::*;
 
+pub use pallet_phala_world::{pallet_pw_incubation, pallet_pw_nft_sale};
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
 pub use subbridge_pallets::{
     chainbridge, fungible_adapter::XTransferAdapter, helper, xcmbridge, xtransfer,
@@ -271,6 +272,8 @@ construct_runtime! {
         RmrkCore: pallet_rmrk_core::{Pallet, Call, Storage, Event<T>} = 102,
         RmrkEquip: pallet_rmrk_equip::{Pallet, Storage, Event<T>} = 103,
         RmrkMarket: pallet_rmrk_market::{Pallet, Call, Storage, Event<T>} = 104,
+        PWNftSale: pallet_pw_nft_sale::{Pallet, Call, Storage, Event<T>} = 105,
+        PWIncubation: pallet_pw_incubation::{Pallet, Call, Storage, Event<T>} = 106,
     }
 }
 
@@ -367,7 +370,7 @@ impl Contains<Call> for BaseCallFilter {
             Call::PhalaMq { .. } | Call::PhalaRegistry { .. } |
             Call::PhalaMining { .. } | Call::PhalaStakePool { .. } |
             // Phala World
-            Call::RmrkMarket { .. }
+            Call::RmrkMarket { .. } | Call::PWNftSale { .. } | Call::PWIncubation { .. }
         )
     }
 }
@@ -889,6 +892,37 @@ impl pallet_rmrk_market::Config for Runtime {
     type ProtocolOrigin = EnsureRoot<AccountId>;
     type Currency = Balances;
     type MinimumOfferAmount = MinimumOfferAmount;
+}
+
+parameter_types! {
+    pub const SecondsPerEra: u64 = 86_400;
+    pub const MinBalanceToClaimSpirit: Balance = 10 * DOLLARS;
+    pub const LegendaryOriginOfShellPrice: Balance = 15_000 * DOLLARS;
+    pub const MagicOriginOfShellPrice: Balance = 10_000 * DOLLARS;
+    pub const PrimeOriginOfShellPrice: Balance = 500 * DOLLARS;
+    pub const IterLimit: u32 = 1_000;
+    pub const FoodPerEra: u32 = 5;
+    pub const MaxFoodFeedSelf: u8 = 2;
+    pub const IncubationDurationSec: u64 = 1_209_600;
+}
+impl pallet_pw_nft_sale::Config for Runtime {
+    type Event = Event;
+    type OverlordOrigin = EnsureRootOrHalfCouncil;
+    type Currency = Balances;
+    type Time = pallet_timestamp::Pallet<Runtime>;
+    type SecondsPerEra = SecondsPerEra;
+    type MinBalanceToClaimSpirit = MinBalanceToClaimSpirit;
+    type LegendaryOriginOfShellPrice = LegendaryOriginOfShellPrice;
+    type MagicOriginOfShellPrice = MagicOriginOfShellPrice;
+    type PrimeOriginOfShellPrice = PrimeOriginOfShellPrice;
+    type IterLimit = IterLimit;
+}
+
+impl pallet_pw_incubation::Config for Runtime {
+    type Event = Event;
+    type FoodPerEra = FoodPerEra;
+    type MaxFoodFeedSelf = MaxFoodFeedSelf;
+    type IncubationDurationSec = IncubationDurationSec;
 }
 
 impl pallet_parachain_info::Config for Runtime {}

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -907,7 +907,7 @@ parameter_types! {
 }
 impl pallet_pw_nft_sale::Config for Runtime {
     type Event = Event;
-    type OverlordOrigin = EnsureRootOrHalfCouncil;
+    type GovernanceOrigin = EnsureRootOrHalfCouncil;
     type Currency = Balances;
     type Time = pallet_timestamp::Pallet<Runtime>;
     type SecondsPerEra = SecondsPerEra;

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -301,12 +301,23 @@ impl Contains<Call> for BaseCallFilter {
 
         if let Call::Uniques(uniques_method) = call {
             return match uniques_method {
-                pallet_uniques::Call::freeze { .. }
-                | pallet_uniques::Call::thaw { .. }
-                | pallet_uniques::Call::set_team { .. }
-                | pallet_uniques::Call::set_attribute { .. }
-                | pallet_uniques::Call::clear_attribute { .. }
-                | pallet_uniques::Call::set_accept_ownership { .. }
+                pallet_uniques::Call::approve_transfer { .. }
+                | pallet_uniques::Call::burn { .. }
+                | pallet_uniques::Call::cancel_approval { .. }
+                | pallet_uniques::Call::clear_class_metadata { .. }
+                | pallet_uniques::Call::clear_metadata { .. }
+                | pallet_uniques::Call::create { .. }
+                | pallet_uniques::Call::destroy { .. }
+                | pallet_uniques::Call::force_asset_status { .. }
+                | pallet_uniques::Call::force_create { .. }
+                | pallet_uniques::Call::freeze_class { .. }
+                | pallet_uniques::Call::mint { .. }
+                | pallet_uniques::Call::redeposit { .. }
+                | pallet_uniques::Call::set_class_metadata { .. }
+                | pallet_uniques::Call::set_metadata { .. }
+                | pallet_uniques::Call::thaw_class { .. }
+                | pallet_uniques::Call::transfer { .. }
+                | pallet_uniques::Call::transfer_ownership { .. }
                 | pallet_uniques::Call::__Ignore { .. } => false,
                 _ => true,
             };

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -67,9 +67,9 @@ use static_assertions::const_assert;
 pub use frame_support::{
     construct_runtime, match_types, parameter_types,
     traits::{
-        Contains, Currency, EnsureOneOf, EqualPrivilegeOnly, Everything, Imbalance, InstanceFilter,
-        IsInVec, KeyOwnerProofSystem, LockIdentifier, Nothing, OnUnbalanced, Randomness,
-        U128CurrencyToVote,
+        AsEnsureOriginWithArg, Contains, Currency, EnsureOneOf, EqualPrivilegeOnly, Everything,
+        Imbalance, InstanceFilter, IsInVec, KeyOwnerProofSystem, LockIdentifier, Nothing,
+        OnUnbalanced, Randomness, U128CurrencyToVote,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -80,7 +80,7 @@ pub use frame_support::{
 
 use frame_system::{
     limits::{BlockLength, BlockWeights},
-    EnsureRoot,
+    EnsureRoot, EnsureSigned,
 };
 
 use pallet_xcm::XcmPassthrough;
@@ -261,6 +261,7 @@ construct_runtime! {
         PhalaStakePool: pallet_stakepool::{Pallet, Call, Event<T>, Storage} = 88,
         Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 89,
         AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 90,
+        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 91,
 
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
         // `OTT` has been removed, the index should be kept
@@ -294,6 +295,19 @@ impl Contains<Call> for BaseCallFilter {
                 | pallet_assets::Call::set_metadata { .. }
                 | pallet_assets::Call::force_set_metadata { .. }
                 | pallet_assets::Call::__Ignore { .. } => false,
+                _ => true,
+            };
+        }
+
+        if let Call::Uniques(uniques_method) = call {
+            return match uniques_method {
+                pallet_uniques::Call::freeze { .. }
+                | pallet_uniques::Call::thaw { .. }
+                | pallet_uniques::Call::set_team { .. }
+                | pallet_uniques::Call::set_attribute { .. }
+                | pallet_uniques::Call::clear_attribute { .. }
+                | pallet_uniques::Call::set_accept_ownership { .. }
+                | pallet_uniques::Call::__Ignore { .. } => false,
                 _ => true,
             };
         }
@@ -778,6 +792,35 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type OutboundXcmpMessageSource = XcmpQueue;
     type XcmpMessageHandler = XcmpQueue;
     type ReservedXcmpWeight = ReservedXcmpWeight;
+}
+
+parameter_types! {
+    pub const ClassDeposit: Balance = 100 * DOLLARS;
+    pub const InstanceDeposit: Balance = 1 * DOLLARS;
+    pub const KeyLimit: u32 = 32;
+    pub const ValueLimit: u32 = 256;
+    pub const StringLimit: u32 = 50;
+}
+
+impl pallet_uniques::Config for Runtime {
+    type Event = Event;
+    type ClassId = u32;
+    type InstanceId = u32;
+    type Currency = Balances;
+    type ForceOrigin = EnsureRoot<AccountId>;
+    type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+    type Locker = ();
+    type ClassDeposit = ClassDeposit;
+    type InstanceDeposit = InstanceDeposit;
+    type MetadataDepositBase = MetadataDepositBase;
+    type AttributeDepositBase = MetadataDepositBase;
+    type DepositPerByte = MetadataDepositPerByte;
+    type StringLimit = StringLimit;
+    type KeyLimit = KeyLimit;
+    type ValueLimit = ValueLimit;
+    #[cfg(feature = "runtime-benchmarks")]
+    type Helper = ();
+    type WeightInfo = pallet_uniques::weights::SubstrateWeight<Runtime>;
 }
 
 impl pallet_parachain_info::Config for Runtime {}
@@ -1533,6 +1576,7 @@ mod benches {
         [pallet_assets, Assets]
         // TODO: panic
         [pallet_collator_selection, CollatorSelection]
+        [pallet_uniques, Uniques]
     );
 }
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -261,11 +261,16 @@ construct_runtime! {
         PhalaStakePool: pallet_stakepool::{Pallet, Call, Event<T>, Storage} = 88,
         Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 89,
         AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 90,
-        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 91,
 
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
         // `OTT` has been removed, the index should be kept
         // PhalaOneshotTransfer: pallet_ott::{Pallet, Call, Event<T>, Storage} = 100,
+
+        // Phala World
+        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 101,
+        RmrkCore: pallet_rmrk_core::{Pallet, Call, Storage, Event<T>} = 102,
+        RmrkEquip: pallet_rmrk_equip::{Pallet, Storage, Event<T>} = 103,
+        RmrkMarket: pallet_rmrk_market::{Pallet, Call, Storage, Event<T>} = 104,
     }
 }
 
@@ -323,6 +328,16 @@ impl Contains<Call> for BaseCallFilter {
             };
         }
 
+        if let Call::RmrkCore(rmrk_core_method) = call {
+            return match rmrk_core_method {
+                pallet_rmrk_core::Call::mint_nft { .. }
+                | pallet_rmrk_core::Call::send { .. }
+                | pallet_rmrk_core::Call::change_collection_issuer { .. }
+                | pallet_rmrk_core::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+
         matches!(
             call,
             Call::Sudo { .. } |
@@ -350,7 +365,9 @@ impl Contains<Call> for BaseCallFilter {
             Call::Lottery { .. } | Call::Tips { .. } |
             // Phala
             Call::PhalaMq { .. } | Call::PhalaRegistry { .. } |
-            Call::PhalaMining { .. } | Call::PhalaStakePool { .. }
+            Call::PhalaMining { .. } | Call::PhalaStakePool { .. } |
+            // Phala World
+            Call::RmrkMarket { .. }
         )
     }
 }
@@ -832,6 +849,46 @@ impl pallet_uniques::Config for Runtime {
     #[cfg(feature = "runtime-benchmarks")]
     type Helper = ();
     type WeightInfo = pallet_uniques::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+    pub const MaxRecursions: u32 = 10;
+    pub const ResourceSymbolLimit: u32 = 10;
+    pub const PartsLimit: u32 = 3;
+    pub const MaxPriorities: u32 = 3;
+    pub const CollectionSymbolLimit: u32 = 100;
+}
+
+impl pallet_rmrk_core::Config for Runtime {
+    type Event = Event;
+    type ProtocolOrigin = EnsureRoot<AccountId>;
+    type MaxRecursions = MaxRecursions;
+    type ResourceSymbolLimit = ResourceSymbolLimit;
+    type PartsLimit = PartsLimit;
+    type MaxPriorities = MaxPriorities;
+    type CollectionSymbolLimit = CollectionSymbolLimit;
+}
+
+parameter_types! {
+    pub const MaxPropertiesPerTheme: u32 = 100;
+    pub const MaxCollectionsEquippablePerPart: u32 = 100;
+}
+
+impl pallet_rmrk_equip::Config for Runtime {
+    type Event = Event;
+    type MaxPropertiesPerTheme = MaxPropertiesPerTheme;
+    type MaxCollectionsEquippablePerPart = MaxCollectionsEquippablePerPart;
+}
+
+parameter_types! {
+    pub const MinimumOfferAmount: Balance = DOLLARS / 10_000;
+}
+
+impl pallet_rmrk_market::Config for Runtime {
+    type Event = Event;
+    type ProtocolOrigin = EnsureRoot<AccountId>;
+    type Currency = Balances;
+    type MinimumOfferAmount = MinimumOfferAmount;
 }
 
 impl pallet_parachain_info::Config for Runtime {}

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -85,6 +85,11 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "releas
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 
+# RMRK dependencies
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
 pallet-parachain-info = { path = "../../pallets/parachain-info", default-features = false }
@@ -201,6 +206,9 @@ std = [
 	"pallet-mq-runtime-api/std",
 	"assets-registry/std",
 	"subbridge-pallets/std",
+	"pallet-rmrk-core/std",
+	"pallet-rmrk-market/std",
+	"pallet-rmrk-equip/std",
 ]
 
 try-runtime = [

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -89,6 +89,7 @@ pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release
 pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
 
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
@@ -96,6 +97,7 @@ pallet-parachain-info = { path = "../../pallets/parachain-info", default-feature
 phala-pallets = { path = "../../pallets/phala", default-features = false }
 pallet-mq-runtime-api = { path = "../../pallets/phala/mq-runtime-api", default-features = false }
 subbridge-pallets = { path = "../../pallets/subbridge", default-features = false }
+pallet-phala-world = { path = "../../pallets/phala-world", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
@@ -209,6 +211,7 @@ std = [
 	"pallet-rmrk-core/std",
 	"pallet-rmrk-market/std",
 	"pallet-rmrk-equip/std",
+	"pallet-phala-world/std",
 ]
 
 try-runtime = [

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -63,6 +63,7 @@ pallet-elections-phragmen = { git = "https://github.com/paritytech/substrate", b
 pallet-tips = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-preimage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22", default-features = false }
 
 # Cumulus dependencies
 pallet-collator-selection = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.22", default-features = false }
@@ -122,6 +123,7 @@ runtime-benchmarks = [
 	"pallet-proxy/runtime-benchmarks",
 	"pallet-utility/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
+	"pallet-uniques/runtime-benchmarks",
 	"pallet-tips/runtime-benchmarks",
 	"phala-pallets/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
@@ -194,6 +196,7 @@ std = [
 	"pallet-tips/std",
 	"pallet-assets/std",
 	"pallet-parachain-info/std",
+	"pallet-uniques/std",
 	"phala-pallets/std",
 	"pallet-mq-runtime-api/std",
 	"assets-registry/std",
@@ -229,5 +232,6 @@ try-runtime = [
 	"pallet-elections-phragmen/try-runtime",
 	"pallet-tips/try-runtime",
 	"pallet-assets/try-runtime",
+	"pallet-uniques/try-runtime",
 	"phala-pallets/try-runtime",
 ]

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -262,6 +262,7 @@ construct_runtime! {
         PhalaStakePool: pallet_stakepool::{Pallet, Call, Event<T>, Storage} = 88,
         Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 89,
         AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 90,
+        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 91,
 
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
         // `OTT` was used in Khala, we avoid to use the index
@@ -357,6 +358,13 @@ impl Contains<Call> for BaseCallFilter {
                 }
                 _ => return false,
             }
+        }
+
+        if let Call::Uniques(uniques_method) = call {
+            match uniques_method {
+                
+            }
+
         }
 
         matches!(

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -925,7 +925,7 @@ parameter_types! {
 }
 impl pallet_pw_nft_sale::Config for Runtime {
     type Event = Event;
-    type OverlordOrigin = EnsureRootOrHalfCouncil;
+    type GovernanceOrigin = EnsureRootOrHalfCouncil;
     type Currency = Balances;
     type Time = pallet_timestamp::Pallet<Runtime>;
     type SecondsPerEra = SecondsPerEra;

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -359,10 +359,6 @@ impl Contains<Call> for BaseCallFilter {
             }
         }
 
-        if let Call::Uniques(uniques_method) = call {
-            match uniques_method {}
-        }
-
         matches!(
             call,
             Call::Sudo { .. } |

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -67,9 +67,9 @@ use static_assertions::const_assert;
 pub use frame_support::{
     construct_runtime, match_types, parameter_types,
     traits::{
-        Contains, Currency, EnsureOneOf, EqualPrivilegeOnly, Everything, Imbalance, InstanceFilter,
-        IsInVec, KeyOwnerProofSystem, LockIdentifier, Nothing, OnUnbalanced, Randomness,
-        U128CurrencyToVote,
+        AsEnsureOriginWithArg, Contains, Currency, EnsureOneOf, EqualPrivilegeOnly, Everything,
+        Imbalance, InstanceFilter, IsInVec, KeyOwnerProofSystem, LockIdentifier, Nothing,
+        OnUnbalanced, Randomness, U128CurrencyToVote,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -80,7 +80,7 @@ pub use frame_support::{
 
 use frame_system::{
     limits::{BlockLength, BlockWeights},
-    EnsureRoot,
+    EnsureRoot, EnsureSigned,
 };
 
 use pallet_xcm::XcmPassthrough;
@@ -261,6 +261,7 @@ construct_runtime! {
         PhalaStakePool: pallet_stakepool::{Pallet, Call, Event<T>, Storage} = 88,
         Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 89,
         AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 90,
+        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 91,
 
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
         // `OTT` was used in Khala, we avoid to use the index
@@ -302,6 +303,23 @@ impl Contains<Call> for BaseCallFilter {
                     return false;
                 }
                 pallet_assets::Call::__Ignore { .. } => {
+                    unimplemented!()
+                }
+                _ => return true,
+            }
+        }
+
+        if let Call::Uniques(uniques_method) = call {
+            match uniques_method {
+                pallet_uniques::Call::freeze { .. }
+                | pallet_uniques::Call::thaw { .. }
+                | pallet_uniques::Call::set_team { .. }
+                | pallet_uniques::Call::set_attribute { .. }
+                | pallet_uniques::Call::clear_attribute { .. }
+                | pallet_uniques::Call::set_accept_ownership { .. } => {
+                    return false;
+                }
+                pallet_uniques::Call::__Ignore { .. } => {
                     unimplemented!()
                 }
                 _ => return true,
@@ -788,6 +806,35 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type OutboundXcmpMessageSource = XcmpQueue;
     type XcmpMessageHandler = XcmpQueue;
     type ReservedXcmpWeight = ReservedXcmpWeight;
+}
+
+parameter_types! {
+    pub const ClassDeposit: Balance = 100 * DOLLARS;
+    pub const InstanceDeposit: Balance = 1 * DOLLARS;
+    pub const KeyLimit: u32 = 32;
+    pub const ValueLimit: u32 = 256;
+    pub const StringLimit: u32 = 50;
+}
+
+impl pallet_uniques::Config for Runtime {
+    type Event = Event;
+    type ClassId = u32;
+    type InstanceId = u32;
+    type Currency = Balances;
+    type ForceOrigin = EnsureRoot<AccountId>;
+    type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+    type Locker = ();
+    type ClassDeposit = ClassDeposit;
+    type InstanceDeposit = InstanceDeposit;
+    type MetadataDepositBase = MetadataDepositBase;
+    type AttributeDepositBase = MetadataDepositBase;
+    type DepositPerByte = MetadataDepositPerByte;
+    type StringLimit = StringLimit;
+    type KeyLimit = KeyLimit;
+    type ValueLimit = ValueLimit;
+    #[cfg(feature = "runtime-benchmarks")]
+    type Helper = ();
+    type WeightInfo = pallet_uniques::weights::SubstrateWeight<Runtime>;
 }
 
 impl pallet_parachain_info::Config for Runtime {}
@@ -1553,6 +1600,7 @@ mod benches {
         [pallet_assets, Assets]
         // TODO: panic
         [pallet_collator_selection, CollatorSelection]
+        [pallet_uniques, Uniques]
     );
 }
 

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -311,12 +311,23 @@ impl Contains<Call> for BaseCallFilter {
 
         if let Call::Uniques(uniques_method) = call {
             match uniques_method {
-                pallet_uniques::Call::freeze { .. }
-                | pallet_uniques::Call::thaw { .. }
-                | pallet_uniques::Call::set_team { .. }
-                | pallet_uniques::Call::set_attribute { .. }
-                | pallet_uniques::Call::clear_attribute { .. }
-                | pallet_uniques::Call::set_accept_ownership { .. } => {
+                pallet_uniques::Call::approve_transfer { .. }
+                | pallet_uniques::Call::burn { .. }
+                | pallet_uniques::Call::cancel_approval { .. }
+                | pallet_uniques::Call::clear_class_metadata { .. }
+                | pallet_uniques::Call::clear_metadata { .. }
+                | pallet_uniques::Call::create { .. }
+                | pallet_uniques::Call::destroy { .. }
+                | pallet_uniques::Call::force_asset_status { .. }
+                | pallet_uniques::Call::force_create { .. }
+                | pallet_uniques::Call::freeze_class { .. }
+                | pallet_uniques::Call::mint { .. }
+                | pallet_uniques::Call::redeposit { .. }
+                | pallet_uniques::Call::set_class_metadata { .. }
+                | pallet_uniques::Call::set_metadata { .. }
+                | pallet_uniques::Call::thaw_class { .. }
+                | pallet_uniques::Call::transfer { .. }
+                | pallet_uniques::Call::transfer_ownership { .. } => {
                     return false;
                 }
                 pallet_uniques::Call::__Ignore { .. } => {

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -262,7 +262,6 @@ construct_runtime! {
         PhalaStakePool: pallet_stakepool::{Pallet, Call, Event<T>, Storage} = 88,
         Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 89,
         AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 90,
-        Uniques: pallet_uniques::{Pallet, Call, Storage, Event<T>} = 91,
 
         Sudo: pallet_sudo::{Pallet, Call, Storage, Config<T>, Event<T>} = 99,
         // `OTT` was used in Khala, we avoid to use the index
@@ -361,10 +360,7 @@ impl Contains<Call> for BaseCallFilter {
         }
 
         if let Call::Uniques(uniques_method) = call {
-            match uniques_method {
-                
-            }
-
+            match uniques_method {}
         }
 
         matches!(

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -98,6 +98,7 @@ use xcm_executor::{Config, XcmExecutor};
 pub use parachains_common::Index;
 pub use parachains_common::*;
 
+pub use pallet_phala_world::{pallet_pw_incubation, pallet_pw_nft_sale};
 pub use phala_pallets::{pallet_mining, pallet_mq, pallet_registry, pallet_stakepool};
 pub use subbridge_pallets::{
     chainbridge, fungible_adapter::XTransferAdapter, helper, xcmbridge, xtransfer,
@@ -271,6 +272,8 @@ construct_runtime! {
         RmrkCore: pallet_rmrk_core::{Pallet, Call, Storage, Event<T>} = 102,
         RmrkEquip: pallet_rmrk_equip::{Pallet, Storage, Event<T>} = 103,
         RmrkMarket: pallet_rmrk_market::{Pallet, Call, Storage, Event<T>} = 104,
+        PWNftSale: pallet_pw_nft_sale::{Pallet, Call, Storage, Event<T>} = 105,
+        PWIncubation: pallet_pw_incubation::{Pallet, Call, Storage, Event<T>} = 106,
     }
 }
 
@@ -385,7 +388,7 @@ impl Contains<Call> for BaseCallFilter {
             Call::PhalaMq { .. } | Call::PhalaRegistry { .. } |
             Call::PhalaMining { .. } | Call::PhalaStakePool { .. } |
             // Phala World
-            Call::RmrkMarket { .. }
+            Call::RmrkMarket { .. } | Call::PWNftSale { .. } | Call::PWIncubation { .. }
         )
     }
 }
@@ -907,6 +910,37 @@ impl pallet_rmrk_market::Config for Runtime {
     type ProtocolOrigin = EnsureRoot<AccountId>;
     type Currency = Balances;
     type MinimumOfferAmount = MinimumOfferAmount;
+}
+
+parameter_types! {
+    pub const SecondsPerEra: u64 = 86_400;
+    pub const MinBalanceToClaimSpirit: Balance = 10 * DOLLARS;
+    pub const LegendaryOriginOfShellPrice: Balance = 15_000 * DOLLARS;
+    pub const MagicOriginOfShellPrice: Balance = 10_000 * DOLLARS;
+    pub const PrimeOriginOfShellPrice: Balance = 500 * DOLLARS;
+    pub const IterLimit: u32 = 1_000;
+    pub const FoodPerEra: u32 = 5;
+    pub const MaxFoodFeedSelf: u8 = 2;
+    pub const IncubationDurationSec: u64 = 1_209_600;
+}
+impl pallet_pw_nft_sale::Config for Runtime {
+    type Event = Event;
+    type OverlordOrigin = EnsureRootOrHalfCouncil;
+    type Currency = Balances;
+    type Time = pallet_timestamp::Pallet<Runtime>;
+    type SecondsPerEra = SecondsPerEra;
+    type MinBalanceToClaimSpirit = MinBalanceToClaimSpirit;
+    type LegendaryOriginOfShellPrice = LegendaryOriginOfShellPrice;
+    type MagicOriginOfShellPrice = MagicOriginOfShellPrice;
+    type PrimeOriginOfShellPrice = PrimeOriginOfShellPrice;
+    type IterLimit = IterLimit;
+}
+
+impl pallet_pw_incubation::Config for Runtime {
+    type Event = Event;
+    type FoodPerEra = FoodPerEra;
+    type MaxFoodFeedSelf = MaxFoodFeedSelf;
+    type IncubationDurationSec = IncubationDurationSec;
 }
 
 impl pallet_parachain_info::Config for Runtime {}


### PR DESCRIPTION
## Targets
- [x] Integrate Uniques Pallet
- [x] Test Functions in Uniques to Ensure BaseFilter Works
- [x] Integrate RMRK Pallet
- [x] Test Functions in RMRK to Ensure BaseFilter Works 
- [x] Integrate Phala World Pallet
- [x] Add Metadata URI from Decentralized Storage for Origin of Shell NFTs
- [x] Implement Privileged Create Collection in Phala World Pallet
- [x] Implement a Giveaway Function for the Giveaway NFTs
- [x] Run Tests on Thala
- [ ] Prepare on Rhala for Staging
- [ ] Prepare for Deployment on Khala

## Procedure
- Integrate Uniques pallet into thala, rhala and khala runtimes
  - Whitelist functions needed in Uniques using BaseFilter
- Integrate RMRK pallet into thala, rhala and khala runtimes
  - Whitelist functions needed in RMRK using BaseFilter
- Integrate Phala World Pallet into thala, rhala and khala runtimes
  - Run tests to ensure Phala World deployment works