### PR TITLE
Update Cargo for Phala World

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-equip"
 version = "0.0.1"
-source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-market"
 version = "0.0.1"
-source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/rmrk-team/rmrk-substrate#82e1bd5b8b7f19cba0e8b1f6c43e986631011caa"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/phala-world/Cargo.toml
+++ b/pallets/phala-world/Cargo.toml
@@ -30,10 +30,10 @@ pallet-balances = { default-features = false, version = "4.0.0-dev", git = "http
 pallet-timestamp = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }
 
 # RMRK dependencies
-pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
 
 [dev-dependencies]
 sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.22" }

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -18,12 +18,6 @@ pub use pallet_rmrk_market;
 use rmrk_traits::{primitives::*, resource::ResourceInfo, AccountIdOrCollectionNftTuple};
 use sp_std::vec::Vec;
 
-pub type ResourceOf<T, R, P> = ResourceInfo<
-	BoundedVec<u8, R>,
-	BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
-	BoundedVec<PartId, P>,
->;
-
 pub use self::pallet::*;
 
 #[frame_support::pallet]

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -86,10 +86,10 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "relea
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 
 # RMRK dependencies
-pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
 
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -86,10 +86,10 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "relea
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 
 # RMRK dependencies
-pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
 
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -86,10 +86,10 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "relea
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.22", default-features = false }
 
 # RMRK dependencies
-pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
-rmrk-traits = { version = "0.0.1", git = "https://github.com/rmrk-team/rmrk-substrate", default-features = false }
+pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
+rmrk-traits = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.22" }
 
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }


### PR DESCRIPTION
Update Cargo to use Phala's fork of rmrk-substrate repo and point to the `polkadot-v0.9.22` branch.