### PR TITLE
Phala World Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-core"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#0b6b25f00a8ae33d0f78ca7133c22020f0f51d19"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-equip"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#0b6b25f00a8ae33d0f78ca7133c22020f0f51d19"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "pallet-rmrk-market"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#0b6b25f00a8ae33d0f78ca7133c22020f0f51d19"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8819,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "rmrk-traits"
 version = "0.0.1"
-source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#84a73f7cd90105c258e6baed69f86c6829b3b840"
+source = "git+https://github.com/Phala-Network/rmrk-substrate?branch=polkadot-v0.9.22#0b6b25f00a8ae33d0f78ca7133c22020f0f51d19"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/phala-world/README.md
+++ b/pallets/phala-world/README.md
@@ -2,10 +2,10 @@
 
 ## Types
 ```rust
-pub enum OriginOfShellType {
-    /// Origin of Shell type is Prime
+pub enum RarityType {
+    /// Rarity Type is Prime
     Prime,
-    /// Origin of Shell type is Magic
+    /// Rarity Type is Magic
     Magic,
     /// Origin of Shell is Legendary
     Legendary,
@@ -175,10 +175,10 @@ signature: sr25519::Signature,
 ```
 
 ### buy_rare_origin_of_shell
-Buy a rare origin of shell of either type Magic or Legendary.
+Buy a rare origin of shell of either rarity type Magic or Legendary.
 ```rust
 origin: OriginFor<T>,
-origin_of_shell_type: OriginOfShellType,
+rarity_type: RarityType,
 race: RaceType,
 career: CareerType,
 ```

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -411,7 +411,7 @@ pub mod pallet {
 				None,
 				None,
 				metadata,
-				false,
+				true,
 			)?;
 			// Set Rarity Type, Race and Career attributes for NFT
 			pallet_pw_nft_sale::Pallet::<T>::set_nft_attributes(

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -1,7 +1,7 @@
 //! Phala World Incubation Pallet
 
 pub use crate::pallet_pw_nft_sale;
-pub use crate::traits::{primitives::*, CareerType, FoodInfo, OriginOfShellType, RaceType};
+pub use crate::traits::{primitives::*, CareerType, FoodInfo, RaceType, RarityType};
 use codec::Decode;
 use frame_support::{
 	ensure,
@@ -151,7 +151,7 @@ pub mod pallet {
 		ShellCollectionIdNotSet,
 		RaceNotDetected,
 		CareerNotDetected,
-		OriginOfShellTypeNotDetected,
+		RarityTypeNotDetected,
 		FoodInfoUpdateError,
 	}
 
@@ -351,29 +351,24 @@ pub mod pallet {
 			);
 			// Check if Shell Collection ID is set
 			let shell_collection_id = Self::get_shell_collection_id()?;
-			// Get race, key and origin of shell type before burning origin of shell NFT
+			// Get race, key and Rarity Type before burning origin of shell NFT
 			let race_key = pallet_pw_nft_sale::pallet::Pallet::<T>::to_boundedvec_key("race")?;
 			let career_key = pallet_pw_nft_sale::pallet::Pallet::<T>::to_boundedvec_key("career")?;
-			let origin_of_shell_type_key =
-				pallet_pw_nft_sale::Pallet::<T>::to_boundedvec_key("origin_of_shell_type")?;
+			let rarity_type_key = pallet_pw_nft_sale::Pallet::<T>::to_boundedvec_key("rarity")?;
 			let race = pallet_uniques::Pallet::<T>::attribute(&collection_id, &nft_id, &race_key)
 				.ok_or(Error::<T>::RaceNotDetected)?;
 			let career =
 				pallet_uniques::Pallet::<T>::attribute(&collection_id, &nft_id, &career_key)
 					.ok_or(Error::<T>::CareerNotDetected)?;
-			let origin_of_shell_type_value = pallet_uniques::Pallet::<T>::attribute(
-				&collection_id,
-				&nft_id,
-				&origin_of_shell_type_key,
-			)
-			.ok_or(Error::<T>::OriginOfShellTypeNotDetected)?;
+			let rarity_type_value =
+				pallet_uniques::Pallet::<T>::attribute(&collection_id, &nft_id, &rarity_type_key)
+					.ok_or(Error::<T>::RarityTypeNotDetected)?;
 			let race_type: RaceType =
 				Decode::decode(&mut race.as_slice()).expect("[race] should not fail");
 			let career_type: CareerType =
 				Decode::decode(&mut career.as_slice()).expect("[career] should not fail");
-			let origin_of_shell_type: OriginOfShellType =
-				Decode::decode(&mut origin_of_shell_type_value.as_slice())
-					.expect("[origin_of_shell_type] should not fail");
+			let rarity_type: RarityType = Decode::decode(&mut rarity_type_value.as_slice())
+				.expect("[rarity] should not fail");
 			// Get Shell Collection next NFT ID
 			let shell_nft_id = pallet_rmrk_core::NextNftId::<T>::get(shell_collection_id);
 			// Burn Origin of Shell NFT then Mint Shell NFT
@@ -399,7 +394,7 @@ pub mod pallet {
 				origin.clone(),
 				collection_id,
 				Some(nft_id),
-				origin_of_shell_type_key,
+				rarity_type_key,
 			)?;
 			// Mint Shell NFT to Overlord to add attributes and resource before sending to owner
 			pallet_rmrk_core::Pallet::<T>::mint_nft(
@@ -410,11 +405,11 @@ pub mod pallet {
 				None,
 				metadata,
 			)?;
-			// Set Origin of Shell Type, Race and Career attributes for NFT
+			// Set Rarity Type, Race and Career attributes for NFT
 			pallet_pw_nft_sale::Pallet::<T>::set_nft_attributes(
 				shell_collection_id,
 				shell_nft_id,
-				origin_of_shell_type,
+				rarity_type,
 				race_type,
 				career_type,
 			)?;

--- a/pallets/phala-world/src/nft_sale.rs
+++ b/pallets/phala-world/src/nft_sale.rs
@@ -19,8 +19,8 @@ pub use pallet_rmrk_core::types::*;
 pub use pallet_rmrk_market;
 
 pub use crate::traits::{
-	primitives::*, CareerType, NftSaleInfo, NftSaleType, OriginOfShellType, OverlordMessage,
-	PreorderInfo, Purpose, RaceType, StatusType,
+	primitives::*, CareerType, NftSaleInfo, NftSaleType, OverlordMessage, PreorderInfo, Purpose,
+	RaceType, RarityType, StatusType,
 };
 use rmrk_traits::primitives::*;
 
@@ -88,14 +88,8 @@ pub mod pallet {
 	/// Origin of Shells inventory
 	#[pallet::storage]
 	#[pallet::getter(fn origin_of_shells_inventory)]
-	pub type OriginOfShellsInventory<T: Config> = StorageDoubleMap<
-		_,
-		Blake2_128Concat,
-		OriginOfShellType,
-		Blake2_128Concat,
-		RaceType,
-		NftSaleInfo,
-	>;
+	pub type OriginOfShellsInventory<T: Config> =
+		StorageDoubleMap<_, Blake2_128Concat, RarityType, Blake2_128Concat, RaceType, NftSaleInfo>;
 
 	/// Phala World Zero Day `BlockNumber` this will be used to determine Eras
 	#[pallet::storage]
@@ -286,7 +280,7 @@ pub mod pallet {
 		},
 		/// Origin of Shell minted from the preorder
 		OriginOfShellMinted {
-			origin_of_shell_type: OriginOfShellType,
+			rarity_type: RarityType,
 			collection_id: CollectionId,
 			nft_id: NftId,
 			owner: T::AccountId,
@@ -298,9 +292,7 @@ pub mod pallet {
 		/// Origin of Shell collection id was set
 		OriginOfShellCollectionIdSet { collection_id: CollectionId },
 		/// Origin of Shell inventory updated
-		OriginOfShellInventoryUpdated {
-			origin_of_shell_type: OriginOfShellType,
-		},
+		OriginOfShellInventoryUpdated { rarity_type: RarityType },
 		/// Spirit Claims status has changed
 		ClaimSpiritStatusChanged { status: bool },
 		/// Purchase Rare Origin of Shells status has changed
@@ -365,7 +357,7 @@ pub mod pallet {
 		OverlordNotSet,
 		RequireOverlordAccount,
 		InvalidStatusType,
-		WrongOriginOfShellType,
+		WrongRarityType,
 		SpiritCollectionNotSet,
 		SpiritCollectionIdAlreadySet,
 		OriginOfShellCollectionNotSet,
@@ -444,13 +436,13 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Buy a rare origin_of_shell of either type Magic or Legendary. Both Origin of Shell types
+		/// Buy a rare origin_of_shell of either type Magic or Legendary. Both Rarity Types
 		/// will have a set price. These will also be limited in quantity and on a first come, first
 		/// serve basis.
 		///
 		/// Parameters:
 		/// - origin: The origin of the extrinsic.
-		/// - origin_of_shell_type: The type of origin_of_shell to be purchased.
+		/// - rarity_type: The type of origin_of_shell to be purchased.
 		/// - race: The race of the origin_of_shell chosen by the user.
 		/// - career: The career of the origin_of_shell chosen by the user or auto-generated based
 		///   on metadata
@@ -458,7 +450,7 @@ pub mod pallet {
 		#[transactional]
 		pub fn buy_rare_origin_of_shell(
 			origin: OriginFor<T>,
-			origin_of_shell_type: OriginOfShellType,
+			rarity_type: RarityType,
 			race: RaceType,
 			career: CareerType,
 		) -> DispatchResult {
@@ -468,17 +460,17 @@ pub mod pallet {
 				Error::<T>::RareOriginOfShellPurchaseNotAvailable
 			);
 			let overlord = Self::overlord()?;
-			// Get Origin of Shell Price based on Origin of ShellType
-			let origin_of_shell_price = match origin_of_shell_type {
-				OriginOfShellType::Legendary => T::LegendaryOriginOfShellPrice::get(),
-				OriginOfShellType::Magic => T::MagicOriginOfShellPrice::get(),
+			// Get Origin of Shell Price based on Rarity Type
+			let origin_of_shell_price = match rarity_type {
+				RarityType::Legendary => T::LegendaryOriginOfShellPrice::get(),
+				RarityType::Magic => T::MagicOriginOfShellPrice::get(),
 				_ => return Err(Error::<T>::InvalidPurchase.into()),
 			};
 			// Mint origin of shell
 			Self::do_mint_origin_of_shell_nft(
 				overlord,
 				sender,
-				origin_of_shell_type,
+				rarity_type,
 				race,
 				career,
 				origin_of_shell_price,
@@ -531,7 +523,7 @@ pub mod pallet {
 			Self::do_mint_origin_of_shell_nft(
 				overlord,
 				sender,
-				OriginOfShellType::Prime,
+				RarityType::Prime,
 				race,
 				career,
 				origin_of_shell_price,
@@ -640,7 +632,7 @@ pub mod pallet {
 					Self::do_mint_origin_of_shell_nft(
 						sender.clone(),
 						preorder_owner.clone(),
-						OriginOfShellType::Prime,
+						RarityType::Prime,
 						preorder_info.race,
 						preorder_info.career,
 						origin_of_shell_price,
@@ -715,7 +707,7 @@ pub mod pallet {
 		/// Parameters:
 		/// `origin`: Expected to come from Overlord admin account
 		/// `owner`: Owner to gift the Origin of Shell to
-		/// - origin_of_shell_type: The type of origin_of_shell to be gifted.
+		/// - rarity_type: The type of origin_of_shell to be gifted.
 		/// - `race`: The race of the origin_of_shell chosen by the user.
 		/// - `career`: The career of the origin_of_shell chosen by the user or auto-generated based
 		///   on metadata
@@ -725,7 +717,7 @@ pub mod pallet {
 		pub fn mint_gift_origin_of_shell(
 			origin: OriginFor<T>,
 			owner: T::AccountId,
-			origin_of_shell_type: OriginOfShellType,
+			rarity_type: RarityType,
 			race: RaceType,
 			career: CareerType,
 			nft_sale_type: NftSaleType,
@@ -742,7 +734,7 @@ pub mod pallet {
 			Self::do_mint_origin_of_shell_nft(
 				sender,
 				owner.clone(),
-				origin_of_shell_type,
+				rarity_type,
 				race,
 				career,
 				Default::default(),
@@ -847,7 +839,7 @@ pub mod pallet {
 		/// Parameters:
 		/// - `origin` - Expected Overlord admin account
 		#[pallet::weight(0)]
-		pub fn init_origin_of_shell_type_counts(origin: OriginFor<T>) -> DispatchResult {
+		pub fn init_rarity_type_counts(origin: OriginFor<T>) -> DispatchResult {
 			// Ensure Overlord account makes call
 			let sender = ensure_signed(origin)?;
 			Self::ensure_overlord(&sender)?;
@@ -864,54 +856,52 @@ pub mod pallet {
 		///
 		/// Parameters:
 		/// - `origin` - Expected Overlord admin account
-		/// - `origin_of_shell_type` - Type of Origin of Shell
+		/// - `rarity_type` - Type of Origin of Shell
 		/// - `for_sale_count` - Number of Origin of Shells for sale
 		/// - `giveaway_count` - Number of Origin of Shells for giveaways
 		/// - `reserve_count` - Number of Origin of Shells to be reserved
 		#[pallet::weight(0)]
-		pub fn update_origin_of_shell_type_counts(
+		pub fn update_rarity_type_counts(
 			origin: OriginFor<T>,
-			origin_of_shell_type: OriginOfShellType,
+			rarity_type: RarityType,
 			for_sale_count: u32,
 			giveaway_count: u32,
 		) -> DispatchResult {
 			// Ensure Overlord account makes call
 			let sender = ensure_signed(origin)?;
 			Self::ensure_overlord(&sender)?;
-			// Ensure they are updating the OriginOfShellType::Prime
+			// Ensure they are updating the RarityType::Prime
 			ensure!(
-				origin_of_shell_type == OriginOfShellType::Prime,
-				Error::<T>::WrongOriginOfShellType
+				rarity_type == RarityType::Prime,
+				Error::<T>::WrongRarityType
 			);
 			// Mutate the existing storage for the Prime Origin of Shells
 			Self::update_nft_sale_info(
-				origin_of_shell_type,
+				rarity_type,
 				RaceType::AISpectre,
 				for_sale_count,
 				giveaway_count,
 			);
 			Self::update_nft_sale_info(
-				origin_of_shell_type,
+				rarity_type,
 				RaceType::Cyborg,
 				for_sale_count,
 				giveaway_count,
 			);
 			Self::update_nft_sale_info(
-				origin_of_shell_type,
+				rarity_type,
 				RaceType::Pandroid,
 				for_sale_count,
 				giveaway_count,
 			);
 			Self::update_nft_sale_info(
-				origin_of_shell_type,
+				rarity_type,
 				RaceType::XGene,
 				for_sale_count,
 				giveaway_count,
 			);
 
-			Self::deposit_event(Event::OriginOfShellInventoryUpdated {
-				origin_of_shell_type,
-			});
+			Self::deposit_event(Event::OriginOfShellInventoryUpdated { rarity_type });
 
 			Ok(())
 		}
@@ -1136,7 +1126,7 @@ where
 	}
 
 	/// Set initial OriginOfShellInventory values in the StorageDoubleMap. Key1 will be of
-	/// OriginOfShellType and Key2 will be the RaceType and the Value will be NftSaleInfo struct
+	/// RarityType and Key2 will be the RaceType and the Value will be NftSaleInfo struct
 	/// containing the information for the NFT sale. Initial config will look as follows:
 	/// `<Legendary>,<RaceType> => NftSaleInfo { race_count: 0, career_count: 0,
 	/// race_for_sale_count: 1, race_giveaway_count: 0, race_reserved_count: 1 }`
@@ -1145,7 +1135,7 @@ where
 	/// `<Prime>,<RaceType> => NftSaleInfo { race_count: 0, career_count: 0, race_for_sale_count:
 	/// 1250, race_giveaway_count: 50, race_reserved_count: 0 }`
 	fn set_initial_origin_of_shell_inventory() -> DispatchResult {
-		// 3 OriginOfShellType Prime, Magic & Legendary and 4 different RaceType Cyborg, AISpectre,
+		// 3 RarityType Prime, Magic & Legendary and 4 different RaceType Cyborg, AISpectre,
 		// XGene & Pandroid
 		ensure!(
 			!IsOriginOfShellsInventorySet::<T>::get(),
@@ -1158,22 +1148,22 @@ where
 			race_reserved_count: 1,
 		};
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Legendary,
+			RarityType::Legendary,
 			RaceType::AISpectre,
 			legendary_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Legendary,
+			RarityType::Legendary,
 			RaceType::Cyborg,
 			legendary_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Legendary,
+			RarityType::Legendary,
 			RaceType::Pandroid,
 			legendary_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Legendary,
+			RarityType::Legendary,
 			RaceType::XGene,
 			legendary_nft_sale_info,
 		);
@@ -1184,22 +1174,22 @@ where
 			race_reserved_count: 10,
 		};
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::AISpectre,
 			magic_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::Cyborg,
 			magic_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::Pandroid,
 			magic_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::XGene,
 			magic_nft_sale_info,
 		);
@@ -1210,22 +1200,22 @@ where
 			race_reserved_count: 0,
 		};
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Prime,
+			RarityType::Prime,
 			RaceType::AISpectre,
 			prime_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Prime,
+			RarityType::Prime,
 			RaceType::Cyborg,
 			prime_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Prime,
+			RarityType::Prime,
 			RaceType::Pandroid,
 			prime_nft_sale_info,
 		);
 		OriginOfShellsInventory::<T>::insert(
-			OriginOfShellType::Prime,
+			RarityType::Prime,
 			RaceType::XGene,
 			prime_nft_sale_info,
 		);
@@ -1235,20 +1225,20 @@ where
 		Ok(())
 	}
 
-	/// Update the NftSaleInfo for a given OriginOfShellType and RaceType
+	/// Update the NftSaleInfo for a given RarityType and RaceType
 	///
 	/// Parameters:
-	/// - `origin_of_shell_type`: OriginOfShellType to update in OriginOfShellInventory
+	/// - `rarity_type`: RarityType to update in OriginOfShellInventory
 	/// - `race`: RaceType to update in OriginOfShellInventory
 	/// - `for_sale_count`: count to increment the for sale count
 	/// - `giveaway_count`: count to increment the race giveaway count
 	fn update_nft_sale_info(
-		origin_of_shell_type: OriginOfShellType,
+		rarity_type: RarityType,
 		race: RaceType,
 		for_sale_count: u32,
 		giveaway_count: u32,
 	) {
-		OriginOfShellsInventory::<T>::mutate(origin_of_shell_type, race, |nft_sale_info| {
+		OriginOfShellsInventory::<T>::mutate(rarity_type, race, |nft_sale_info| {
 			if let Some(nft_sale_info) = nft_sale_info {
 				nft_sale_info.race_for_sale_count = nft_sale_info
 					.race_for_sale_count
@@ -1308,13 +1298,13 @@ where
 	/// Parameters:
 	/// - `overlord`
 	/// - `sender`
-	/// - `origin_of_shell_type`
+	/// - `rarity_type`
 	/// - `race`
 	/// - `career`
 	fn do_mint_origin_of_shell_nft(
 		overlord: T::AccountId,
 		sender: T::AccountId,
-		origin_of_shell_type: OriginOfShellType,
+		rarity_type: RarityType,
 		race: RaceType,
 		career: CareerType,
 		price: BalanceOf<T>,
@@ -1341,7 +1331,7 @@ where
 		// Get the Race's Origin of Shell metadata
 		let metadata = Self::get_origin_of_shell_metadata(race)?;
 		// Check if race and career types have mints left
-		Self::has_race_type_left(origin_of_shell_type, race, nft_sale_type)?;
+		Self::has_race_type_left(rarity_type, race, nft_sale_type)?;
 		// Transfer the amount for the rare Origin of Shell NFT then mint the origin_of_shell
 		<T as pallet::Config>::Currency::transfer(
 			&sender,
@@ -1358,17 +1348,17 @@ where
 			None,
 			metadata,
 		)?;
-		// Set Origin of Shell Type, Race and Career attributes for NFT
+		// Set Rarity Type, Race and Career attributes for NFT
 		Self::set_nft_attributes(
 			origin_of_shell_collection_id,
 			nft_id,
-			origin_of_shell_type,
+			rarity_type,
 			race,
 			career,
 		)?;
 		// Update storage
-		Self::decrement_race_type_left(origin_of_shell_type, race, nft_sale_type)?;
-		Self::increment_race_type(origin_of_shell_type, race)?;
+		Self::decrement_race_type_left(rarity_type, race, nft_sale_type)?;
+		Self::increment_race_type(rarity_type, race)?;
 		Self::increment_career_type(career);
 
 		// Freeze NFT so it cannot be transferred
@@ -1379,7 +1369,7 @@ where
 		)?;
 
 		Self::deposit_event(Event::OriginOfShellMinted {
-			origin_of_shell_type,
+			rarity_type,
 			collection_id: origin_of_shell_collection_id,
 			nft_id,
 			owner: sender,
@@ -1390,29 +1380,28 @@ where
 		Ok(())
 	}
 
-	/// Set the attributes for Origin of Shell or Shell NFT's type, race and career.
+	/// Set the attributes for Origin of Shell or Shell NFT's rarity, race and career.
 	///
 	/// Parameters:
 	/// - `collection_id`: Collection id of the Origin of Shell or Shell NFT
 	/// - `nft_id`: NFT id of the Origin of Shell or Shell NFT
-	/// - `origin_of_shell_type`: Origin of Shell or Shell type for the NFT
+	/// - `rarity_type`: Origin of Shell or Shell rarity type for the NFT
 	/// - `race`: Race attribute to set for the Origin of Shell or Shell NFT
 	/// - `career`: Career attribute to set for the Origin of Shell or Shell NFT
 	pub(crate) fn set_nft_attributes(
 		collection_id: CollectionId,
 		nft_id: NftId,
-		origin_of_shell_type: OriginOfShellType,
+		rarity_type: RarityType,
 		race: RaceType,
 		career: CareerType,
 	) -> DispatchResult {
 		let overlord = Self::overlord()?;
 
-		let origin_of_shell_type_key: BoundedVec<u8, T::KeyLimit> =
-			Self::to_boundedvec_key("origin_of_shell_type")?;
-		let origin_of_shell_type_value = origin_of_shell_type
+		let rarity_type_key: BoundedVec<u8, T::KeyLimit> = Self::to_boundedvec_key("rarity")?;
+		let rarity_type_value = rarity_type
 			.encode()
 			.try_into()
-			.expect("[origin_of_shell_type] should not fail");
+			.expect("[rarity] should not fail");
 
 		let race_key: BoundedVec<u8, T::KeyLimit> = Self::to_boundedvec_key("race")?;
 		let race_value = race.encode().try_into().expect("[race] should not fail");
@@ -1423,13 +1412,13 @@ where
 			.try_into()
 			.expect("[career] should not fail");
 
-		// Set Origin of Shell Type
+		// Set Rarity Type
 		pallet_uniques::Pallet::<T>::set_attribute(
 			Origin::<T>::Signed(overlord.clone()).into(),
 			collection_id,
 			Some(nft_id),
-			origin_of_shell_type_key,
-			origin_of_shell_type_value,
+			rarity_type_key,
+			rarity_type_value,
 		)?;
 		// Set Race
 		pallet_uniques::Pallet::<T>::set_attribute(
@@ -1465,14 +1454,11 @@ where
 	/// Increment RaceType count for the `race`
 	///
 	/// Parameters:
-	/// - `origin_of_shell_type`: Origin of Shell type
+	/// - `rarity_type`: Rarity Type
 	/// - `race`: The Career to increment count
-	fn increment_race_type(
-		origin_of_shell_type: OriginOfShellType,
-		race: RaceType,
-	) -> DispatchResult {
+	fn increment_race_type(rarity_type: RarityType, race: RaceType) -> DispatchResult {
 		OriginOfShellsInventory::<T>::try_mutate_exists(
-			origin_of_shell_type,
+			rarity_type,
 			race,
 			|nft_sale_info| -> DispatchResult {
 				if let Some(nft_sale_info) = nft_sale_info {
@@ -1501,12 +1487,12 @@ where
 	/// Parameters:
 	/// - `race`: The Race to increment count
 	fn decrement_race_type_left(
-		origin_of_shell_type: OriginOfShellType,
+		rarity_type: RarityType,
 		race: RaceType,
 		nft_sale_type: NftSaleType,
 	) -> DispatchResult {
 		OriginOfShellsInventory::<T>::try_mutate_exists(
-			origin_of_shell_type,
+			rarity_type,
 			race,
 			|nft_sale_info| -> DispatchResult {
 				if let Some(nft_sale_info) = nft_sale_info {
@@ -1534,11 +1520,11 @@ where
 	/// Parameters:
 	/// - `race`: The Race to check
 	fn has_race_type_left(
-		origin_of_shell_type: OriginOfShellType,
+		rarity_type: RarityType,
 		race: RaceType,
 		nft_sale_type: NftSaleType,
 	) -> DispatchResult {
-		if let Some(nft_sale_info) = OriginOfShellsInventory::<T>::get(origin_of_shell_type, race) {
+		if let Some(nft_sale_info) = OriginOfShellsInventory::<T>::get(rarity_type, race) {
 			match nft_sale_type {
 				NftSaleType::ForSale => {
 					ensure!(

--- a/pallets/phala-world/src/nft_sale.rs
+++ b/pallets/phala-world/src/nft_sale.rs
@@ -793,8 +793,9 @@ pub mod pallet {
 			Self::ensure_overlord(&sender)?;
 			// Ensure ZeroDay is None as this can only be set once
 			ensure!(Self::zero_day() == None, Error::<T>::WorldClockAlreadySet);
+			let now = T::Time::now().as_secs();
 
-			let zero_day = T::Time::now().as_secs();
+			let zero_day = now - (now % T::SecondsPerEra::get());
 
 			ZeroDay::<T>::put(zero_day);
 			Self::deposit_event(Event::WorldClockStarted {

--- a/pallets/phala-world/src/nft_sale.rs
+++ b/pallets/phala-world/src/nft_sale.rs
@@ -1282,7 +1282,7 @@ where
 			None,
 			None,
 			metadata,
-			false,
+			true,
 		)?;
 		// Freeze NFT so it cannot be transferred
 		pallet_uniques::Pallet::<T>::freeze(
@@ -1356,7 +1356,7 @@ where
 			None,
 			None,
 			metadata,
-			false,
+			true,
 		)?;
 		// Set Rarity Type, Race and Career attributes for NFT
 		Self::set_nft_attributes(

--- a/pallets/phala-world/src/tests.rs
+++ b/pallets/phala-world/src/tests.rs
@@ -8,7 +8,7 @@ use frame_support::{assert_noop, assert_ok, error::BadOrigin, traits::Currency, 
 use sp_core::{crypto::AccountId32, sr25519, Pair};
 
 use crate::traits::{
-	primitives::*, CareerType, NftSaleType, OriginOfShellType, OverlordMessage, Purpose, RaceType,
+	primitives::*, CareerType, NftSaleType, OverlordMessage, Purpose, RaceType, RarityType,
 	StatusType,
 };
 use mock::{Call, Event as MockEvent, ExtBuilder, Origin, PWIncubation, PWNftSale, RmrkCore, Test};
@@ -104,9 +104,7 @@ fn setup_config(enable_status_type: StatusType) {
 	// Initialize the Phala World Clock
 	assert_ok!(PWNftSale::initialize_world_clock(Origin::signed(OVERLORD)));
 	// Initialize Origin of Shell Inventory numbers
-	assert_ok!(PWNftSale::init_origin_of_shell_type_counts(Origin::signed(
-		OVERLORD
-	)));
+	assert_ok!(PWNftSale::init_rarity_type_counts(Origin::signed(OVERLORD)));
 	match enable_status_type {
 		StatusType::ClaimSpirits => {
 			assert_ok!(PWNftSale::set_status_type(
@@ -282,14 +280,14 @@ fn purchase_rare_origin_of_shell_works() {
 		// ALICE purchases Legendary Origin of Shell
 		assert_ok!(PWNftSale::buy_rare_origin_of_shell(
 			Origin::signed(ALICE),
-			OriginOfShellType::Legendary,
+			RarityType::Legendary,
 			RaceType::AISpectre,
 			CareerType::HackerWizard,
 		));
 		// Check if event triggered
 		System::assert_last_event(MockEvent::PWNftSale(
 			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
-				origin_of_shell_type: OriginOfShellType::Legendary,
+				rarity_type: RarityType::Legendary,
 				collection_id: 1,
 				nft_id: 0,
 				owner: ALICE,
@@ -301,7 +299,7 @@ fn purchase_rare_origin_of_shell_works() {
 		assert_noop!(
 			PWNftSale::buy_rare_origin_of_shell(
 				Origin::signed(BOB),
-				OriginOfShellType::Legendary,
+				RarityType::Legendary,
 				RaceType::Cyborg,
 				CareerType::HardwareDruid,
 			),
@@ -310,14 +308,14 @@ fn purchase_rare_origin_of_shell_works() {
 		// BOB purchases Magic Origin of Shell
 		assert_ok!(PWNftSale::buy_rare_origin_of_shell(
 			Origin::signed(BOB),
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::Cyborg,
 			CareerType::HardwareDruid,
 		));
 		// Check if event triggered
 		System::assert_last_event(MockEvent::PWNftSale(
 			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
-				origin_of_shell_type: OriginOfShellType::Magic,
+				rarity_type: RarityType::Magic,
 				collection_id: 1,
 				nft_id: 1,
 				owner: BOB,
@@ -329,7 +327,7 @@ fn purchase_rare_origin_of_shell_works() {
 		assert_noop!(
 			PWNftSale::buy_rare_origin_of_shell(
 				Origin::signed(CHARLIE),
-				OriginOfShellType::Prime,
+				RarityType::Prime,
 				RaceType::Pandroid,
 				CareerType::HackerWizard,
 			),
@@ -338,14 +336,14 @@ fn purchase_rare_origin_of_shell_works() {
 		// CHARLIE purchases Magic Origin Of Shell
 		assert_ok!(PWNftSale::buy_rare_origin_of_shell(
 			Origin::signed(CHARLIE),
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::Pandroid,
 			CareerType::HackerWizard,
 		));
 		// Check if event triggered
 		System::assert_last_event(MockEvent::PWNftSale(
 			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
-				origin_of_shell_type: OriginOfShellType::Magic,
+				rarity_type: RarityType::Magic,
 				collection_id: 1,
 				nft_id: 2,
 				owner: CHARLIE,
@@ -419,7 +417,7 @@ fn purchase_prime_origin_of_shell_works() {
 		// Check if event triggered
 		System::assert_last_event(MockEvent::PWNftSale(
 			crate::pallet_pw_nft_sale::Event::OriginOfShellMinted {
-				origin_of_shell_type: OriginOfShellType::Prime,
+				rarity_type: RarityType::Prime,
 				collection_id: 1,
 				nft_id: 0,
 				owner: BOB,
@@ -706,7 +704,7 @@ fn mint_gift_origin_of_shell_works() {
 		assert_ok!(PWNftSale::mint_gift_origin_of_shell(
 			Origin::signed(OVERLORD),
 			CHARLIE,
-			OriginOfShellType::Magic,
+			RarityType::Magic,
 			RaceType::XGene,
 			CareerType::Web3Monk,
 			NftSaleType::Reserved,
@@ -732,16 +730,16 @@ fn mint_gift_origin_of_shell_works() {
 			},
 		));
 		// Update inventory to have a giveaway then gift giveaway
-		assert_ok!(PWNftSale::update_origin_of_shell_type_counts(
+		assert_ok!(PWNftSale::update_rarity_type_counts(
 			Origin::signed(OVERLORD),
-			OriginOfShellType::Prime,
+			RarityType::Prime,
 			0,
 			1
 		));
 		assert_ok!(PWNftSale::mint_gift_origin_of_shell(
 			Origin::signed(OVERLORD),
 			CHARLIE,
-			OriginOfShellType::Prime,
+			RarityType::Prime,
 			RaceType::Cyborg,
 			CareerType::HackerWizard,
 			NftSaleType::Giveaway,
@@ -751,7 +749,7 @@ fn mint_gift_origin_of_shell_works() {
 			PWNftSale::mint_gift_origin_of_shell(
 				Origin::signed(OVERLORD),
 				CHARLIE,
-				OriginOfShellType::Prime,
+				RarityType::Prime,
 				RaceType::Cyborg,
 				CareerType::HackerWizard,
 				NftSaleType::Giveaway,

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -10,6 +10,7 @@ use sp_std::cmp::Eq;
 pub mod primitives {
 	pub type PreorderId = u32;
 	pub type EraId = u64;
+	pub type GenerationId = u32;
 }
 
 /// Status types for different NFT Sale phases

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -37,10 +37,10 @@ pub struct OverlordMessage<AccountId> {
 	pub purpose: Purpose,
 }
 
-/// Origin of Shell Types of Prime, Magic & Legendary
+/// Rarity Types of Prime, Magic & Legendary
 #[derive(Encode, Decode, Clone, Copy, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum OriginOfShellType {
+pub enum RarityType {
 	Prime,
 	Magic,
 	Legendary,
@@ -91,7 +91,7 @@ pub enum NftSaleType {
 }
 
 /// NftSaleInfo is used as the value in the StorageDoubleMap that takes key1 as the
-/// OriginOfShellType and key2 as the RaceType
+/// RarityType and key2 as the RaceType
 #[derive(Encode, Decode, Eq, PartialEq, Clone, Copy, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct NftSaleInfo {
 	/// Number of Race Type count

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -336,9 +336,7 @@ impl Contains<Call> for BaseCallFilter {
 
         if let Call::RmrkCore(rmrk_core_method) = call {
             return match rmrk_core_method {
-                pallet_rmrk_core::Call::mint_nft { .. }
-                | pallet_rmrk_core::Call::send { .. }
-                | pallet_rmrk_core::Call::change_collection_issuer { .. }
+                pallet_rmrk_core::Call::change_collection_issuer { .. }
                 | pallet_rmrk_core::Call::__Ignore { .. } => true,
                 _ => false,
             };

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -337,9 +337,7 @@ impl Contains<Call> for BaseCallFilter {
 
         if let Call::RmrkCore(rmrk_core_method) = call {
             return match rmrk_core_method {
-                pallet_rmrk_core::Call::mint_nft { .. }
-                | pallet_rmrk_core::Call::send { .. }
-                | pallet_rmrk_core::Call::change_collection_issuer { .. }
+                pallet_rmrk_core::Call::change_collection_issuer { .. }
                 | pallet_rmrk_core::Call::__Ignore { .. } => true,
                 _ => false,
             };

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -348,9 +348,7 @@ impl Contains<Call> for BaseCallFilter {
 
         if let Call::RmrkCore(rmrk_core_method) = call {
             match rmrk_core_method {
-                pallet_rmrk_core::Call::mint_nft { .. }
-                | pallet_rmrk_core::Call::send { .. }
-                | pallet_rmrk_core::Call::change_collection_issuer { .. } => {
+                pallet_rmrk_core::Call::change_collection_issuer { .. } => {
                     return true;
                 }
                 pallet_rmrk_core::Call::__Ignore { .. } => {


### PR DESCRIPTION
# Targets
- [x] Change ZeroDay Timestamp to be at 00:00:00 UTC when `initialize_world_clock` is executed by `Overlord`
- [x] Update `OriginOfShellType` to `RarityType`
- [x] Add `generation` attribute for Origin of Shell and Shell NFTs
- [x] Limit Preorders per account