### PR TITLE
Disable local account send xcm

### DIFF
--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1091,7 +1091,8 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 
 impl pallet_xcm::Config for Runtime {
     type Event = Event;
-    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    /// No local origins on this chain are allowed to dispatch XCM sends.
+    type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>;
     type XcmRouter = XcmRouter;
     type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
     type XcmExecuteFilter = Nothing;

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1064,7 +1064,6 @@ impl Config for XcmConfig {
 parameter_types! {
     pub const MaxDownwardMessageWeight: Weight = MAXIMUM_BLOCK_WEIGHT / 10;
 }
-/// No local origins on this chain are allowed to dispatch XCM sends/executions.
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNetwork>;
 
 /// The means for routing XCM messages which are not for local execution into the right message
@@ -1098,7 +1097,8 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 
 impl pallet_xcm::Config for Runtime {
     type Event = Event;
-    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    /// No local origins on this chain are allowed to dispatch XCM sends.
+    type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>;
     type XcmRouter = XcmRouter;
     type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
     type XcmExecuteFilter = Nothing;

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -283,7 +283,6 @@ impl Contains<Call> for BaseCallFilter {
     fn contains(call: &Call) -> bool {
         if let Call::PolkadotXcm(xcm_method) = call {
             match xcm_method {
-                pallet_xcm::Call::send { .. }
                 | pallet_xcm::Call::execute { .. }
                 | pallet_xcm::Call::teleport_assets { .. }
                 | pallet_xcm::Call::reserve_transfer_assets { .. }
@@ -294,7 +293,8 @@ impl Contains<Call> for BaseCallFilter {
                 pallet_xcm::Call::force_xcm_version { .. }
                 | pallet_xcm::Call::force_default_xcm_version { .. }
                 | pallet_xcm::Call::force_subscribe_version_notify { .. }
-                | pallet_xcm::Call::force_unsubscribe_version_notify { .. } => {
+                | pallet_xcm::Call::force_unsubscribe_version_notify { .. }
+                | pallet_xcm::Call::send { .. } => {
                     return true;
                 }
                 pallet_xcm::Call::__Ignore { .. } => {
@@ -1119,7 +1119,8 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 
 impl pallet_xcm::Config for Runtime {
     type Event = Event;
-    type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+    /// No local origins on this chain are allowed to dispatch XCM sends.
+    type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>;
     type XcmRouter = XcmRouter;
     type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
     type XcmExecuteFilter = Nothing;


### PR DESCRIPTION
Before this change, local account sends XCM to other parachains maybe get failed because inserted instruction `DescendOrigin` according to the barrier config of dest chain. However if some barrier config missed on dest chain, unexpected thing could happen. So far we havn't see any use case that local user needs send XCM to other parachains, it's ok just disable it.