### PR TITLE
Loosen StringLimit for unique pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "fixed-macro"
 version = "1.1.1"
-source = "git+https://github.com/kvinwang/fixed-macro.git#fe688ef1dbb350c67d4be00bb808f726439289dd"
+source = "git+https://github.com/kvinwang/fixed-macro#fe688ef1dbb350c67d4be00bb808f726439289dd"
 dependencies = [
  "fixed",
  "fixed-macro-impl",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "fixed-macro-impl"
 version = "1.1.1"
-source = "git+https://github.com/kvinwang/fixed-macro.git#fe688ef1dbb350c67d4be00bb808f726439289dd"
+source = "git+https://github.com/kvinwang/fixed-macro#fe688ef1dbb350c67d4be00bb808f726439289dd"
 dependencies = [
  "fixed",
  "paste",
@@ -2484,7 +2484,7 @@ dependencies = [
 [[package]]
 name = "fixed-macro-types"
 version = "1.1.1"
-source = "git+https://github.com/kvinwang/fixed-macro.git#fe688ef1dbb350c67d4be00bb808f726439289dd"
+source = "git+https://github.com/kvinwang/fixed-macro#fe688ef1dbb350c67d4be00bb808f726439289dd"
 dependencies = [
  "fixed",
  "fixed-macro-impl",

--- a/pallets/phala-world/Cargo.toml
+++ b/pallets/phala-world/Cargo.toml
@@ -13,31 +13,31 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.111", default-features = false, features = ["derive"] }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
-	"derive",
-] }
-sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23"}
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", optional = true }
+codec = { package = "parity-scale-codec", version = "3.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.0", default-features = false, features = ["derive"] }
 
-pallet-uniques = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-pallet-balances = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-pallet-timestamp = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false, optional = true }
+
+pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
 
 # RMRK dependencies
-pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.23" }
-pallet-rmrk-equip = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.23" }
-pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.23" }
-rmrk-traits = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.23" }
+pallet-rmrk-core = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.23", default-features = false }
+pallet-rmrk-equip = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.23", default-features = false }
+pallet-rmrk-market = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.23", default-features = false }
+rmrk-traits = { git = "https://github.com/Phala-Network/rmrk-substrate", branch = "polkadot-v0.9.23", default-features = false }
 
 [dev-dependencies]
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
-sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/phala-world/Cargo.toml
+++ b/pallets/phala-world/Cargo.toml
@@ -13,21 +13,21 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 serde = { version = "1.0.111", default-features = false, features = ["derive"] }
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
-sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }
-sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
-sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
+sp-core = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-io = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23"}
-frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
-frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23", optional = true }
+frame-support = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23"}
+frame-system = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+frame-benchmarking = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23", optional = true }
 
-pallet-uniques = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
-pallet-balances = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
-pallet-timestamp = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
+pallet-uniques = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+pallet-balances = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+pallet-timestamp = { default-features = false, version = "4.0.0-dev", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 
 # RMRK dependencies
 pallet-rmrk-core = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.23" }
@@ -36,8 +36,8 @@ pallet-rmrk-market = { version = "0.0.1", git = "https://github.com/Phala-Networ
 rmrk-traits = { version = "0.0.1", git = "https://github.com/Phala-Network/rmrk-substrate", default-features = false, branch = "polkadot-v0.9.23" }
 
 [dev-dependencies]
-sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
-sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.23" }
+sp-runtime = { default-features = false, version = "6.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
+sp-std = { default-features = false, version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.23" }
 
 [features]
 default = ["std"]

--- a/pallets/phala-world/src/lib.rs
+++ b/pallets/phala-world/src/lib.rs
@@ -1,13 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+mod traits;
+
 pub mod incubation;
 pub mod nft_sale;
 
 // Alias
 pub use incubation as pallet_pw_incubation;
 pub use nft_sale as pallet_pw_nft_sale;
-
-#[cfg(test)]
-mod mock;
-mod tests;
-mod traits;

--- a/pallets/phala-world/src/mock.rs
+++ b/pallets/phala-world/src/mock.rs
@@ -1,16 +1,14 @@
-use super::*;
-use crate::{pallet_pw_incubation, pallet_pw_nft_sale, traits};
+use crate::{pallet_pw_incubation, pallet_pw_nft_sale};
 
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
-		AsEnsureOriginWithArg, ConstU32, ConstU64, Everything, GenesisBuild, OnFinalize,
-		OnInitialize,
+		AsEnsureOriginWithArg, ConstU32, Everything, GenesisBuild, OnFinalize,
 	},
 	weights::Weight,
 };
 use frame_system::EnsureRoot;
-use sp_core::{crypto::AccountId32, sr25519::Signature, Pair, Public, H256};
+use sp_core::{crypto::AccountId32, H256};
 
 use sp_runtime::{
 	testing::Header,
@@ -27,7 +25,7 @@ pub const BLOCK_TIME: u64 = 1_000;
 pub const INIT_TIMESTAMP_SECONDS: u64 = 30;
 pub const BLOCK_TIME_SECONDS: u64 = 1;
 // Configure a mock runtime to test the pallet.
-frame_support::construct_runtime!(
+construct_runtime!(
 	pub enum Test where
 		Block = Block,
 		NodeBlock = Block,
@@ -57,7 +55,7 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
@@ -117,12 +115,12 @@ impl pallet_rmrk_core::Config for Test {
 parameter_types! {
 	pub const CollectionDeposit: Balance = 10_000 * PHA; // 1 UNIT deposit to create collection
 	pub const ItemDeposit: Balance = 100 * PHA; // 1/100 UNIT deposit to create item
-	pub const KeyLimit: u32 = 32;	// Max 32 bytes per key
-	pub const ValueLimit: u32 = 64;	// Max 64 bytes per value
+	pub const StringLimit: u32 = 64;
+	pub const KeyLimit: u32 = 32; // Max 32 bytes per key
+	pub const ValueLimit: u32 = 256; // Max 64 bytes per value
 	pub const UniquesMetadataDepositBase: Balance = 1000 * PHA;
 	pub const AttributeDepositBase: Balance = 100 * PHA;
 	pub const DepositPerByte: Balance = 10 * PHA;
-	pub const UniquesStringLimit: u32 = 32;
 }
 
 impl pallet_uniques::Config for Test {
@@ -138,7 +136,7 @@ impl pallet_uniques::Config for Test {
 	type MetadataDepositBase = UniquesMetadataDepositBase;
 	type AttributeDepositBase = AttributeDepositBase;
 	type DepositPerByte = DepositPerByte;
-	type StringLimit = UniquesStringLimit;
+	type StringLimit = StringLimit;
 	type KeyLimit = KeyLimit;
 	type ValueLimit = ValueLimit;
 	type WeightInfo = ();

--- a/pallets/phala-world/src/tests.rs
+++ b/pallets/phala-world/src/tests.rs
@@ -11,11 +11,10 @@ use crate::traits::{
 	primitives::*, CareerType, NftSaleType, OverlordMessage, Purpose, RaceType, RarityType,
 	StatusType,
 };
-use mock::{Call, Event as MockEvent, ExtBuilder, Origin, PWIncubation, PWNftSale, RmrkCore, Test};
-use rmrk_traits::primitives::*;
+use mock::{Event as MockEvent, ExtBuilder, Origin, PWIncubation, PWNftSale, RmrkCore, Test};
 
 /// Turns a string into a BoundedVec
-fn stb(s: &str) -> BoundedVec<u8, UniquesStringLimit> {
+fn stb(s: &str) -> BoundedVec<u8, StringLimit> {
 	s.as_bytes().to_vec().try_into().unwrap()
 }
 
@@ -36,9 +35,9 @@ macro_rules! bvec {
 }
 
 fn metadata_accounts(
-	mut alice_metadata: BoundedVec<u8, UniquesStringLimit>,
-	mut bob_metadata: BoundedVec<u8, UniquesStringLimit>,
-	mut charlie_metadata: BoundedVec<u8, UniquesStringLimit>,
+	mut alice_metadata: BoundedVec<u8, StringLimit>,
+	mut bob_metadata: BoundedVec<u8, StringLimit>,
+	mut charlie_metadata: BoundedVec<u8, StringLimit>,
 ) {
 	alice_metadata = stb("I am ALICE");
 	bob_metadata = stb("I am BOB");

--- a/pallets/phala/Cargo.toml
+++ b/pallets/phala/Cargo.toml
@@ -36,7 +36,7 @@ hex = { version = "0.4", default-features = false }
 hex-literal = "0.3.1"
 serde_json = { version = "1.0.41", default-features = false, features = ["alloc"] }
 fixed = { version = "1.9", default-features = false }
-fixed-macro = { git = "https://github.com/kvinwang/fixed-macro.git", version = "1.1", default-features = false }
+fixed-macro = { git = "https://github.com/kvinwang/fixed-macro", version = "1.1", default-features = false }
 fixed-sqrt = { version = "0.2", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -812,7 +812,7 @@ parameter_types! {
     pub const ItemDeposit: Balance = 1 * DOLLARS;
     pub const KeyLimit: u32 = 32;
     pub const ValueLimit: u32 = 256;
-    pub const StringLimit: u32 = 50;
+    pub const StringLimit: u32 = 128;
 }
 
 impl pallet_uniques::Config for Runtime {

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -819,7 +819,7 @@ parameter_types! {
     pub const ItemDeposit: Balance = 1 * DOLLARS;
     pub const KeyLimit: u32 = 32;
     pub const ValueLimit: u32 = 256;
-    pub const StringLimit: u32 = 50;
+    pub const StringLimit: u32 = 128;
 }
 
 impl pallet_uniques::Config for Runtime {

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -816,7 +816,7 @@ parameter_types! {
     pub const ItemDeposit: Balance = 1 * DOLLARS;
     pub const KeyLimit: u32 = 32;
     pub const ValueLimit: u32 = 256;
-    pub const StringLimit: u32 = 50;
+    pub const StringLimit: u32 = 128;
 }
 
 impl pallet_uniques::Config for Runtime {


### PR DESCRIPTION
A typical Arweave uri required 63 bytes, this PR loosen StringLimit to 128 bytes which give us more room to store metadata uri.

Additionally, clean some compiling warnings