### PR TITLE
Return last bridge error when crosschain transfer failed to execute

### DIFF
--- a/pallets/subbridge/src/xtransfer.rs
+++ b/pallets/subbridge/src/xtransfer.rs
@@ -219,7 +219,7 @@ pub mod pallet {
 						Some(6_000_000_000u64),
 					),
 					// Both XcmBridge and ChainBridge will failed with "CannotDepositAsset", however XcmBridge
-					// will run first, then ChainBridge will run according to all mock runtime definition.
+					// will run first, then ChainBridge will run according to our mock runtime definition.
 					// And we always return the last error when iterating all configured bridges.
 					ChainbridgeError::<Runtime>::CannotDepositAsset,
 				);
@@ -375,7 +375,7 @@ pub mod pallet {
 						None,
 					),
 					// Both XcmBridge and ChainBridge will failed with "CannotDepositAsset", however XcmBridge
-					// will run first, then ChainBridge will run according to all mock runtime definition.
+					// will run first, then ChainBridge will run according to our mock runtime definition.
 					// And we always return the last error when iterating all configured bridges.
 					ChainbridgeError::<Runtime>::CannotDepositAsset,
 				);


### PR DESCRIPTION
Previously we return error `TransactFailed` ambiguously by ignore the returned bridges errors,  which is hard to recognize what error throw by bridges when crosschain transfer failed to execute. Consequently return dispatch error directly can solve portion of this problem. However if both XcmBridge and ChainBridge failed, we will return the last error when iterating all configured bridges. Because we run XcmBridge first, then run ChainBridge according to our runtime definition. 