### PR TITLE
Automating Test Chain State Scripts & Increase Test Coverage Scenarios

### DIFF
--- a/scripts/js/pw/khala/khalaApi.js
+++ b/scripts/js/pw/khala/khalaApi.js
@@ -1,0 +1,23 @@
+require('dotenv').config();
+const { ApiPromise, WsProvider } = require('@polkadot/api');
+
+const endpoint = process.env.ENDPOINT;
+
+export async function getApiConnection() {
+    const wsProvider = new WsProvider(endpoint);
+    return await ApiPromise.create({
+        provider: wsProvider,
+        types: {
+            Purpose: {
+                _enum: [
+                    'RedeemSpirit',
+                    'BuyPrimeOriginOfShells',
+                ],
+            },
+            OverlordMessage: {
+                account: 'AccountId',
+                purpose: 'Purpose',
+            }
+        }
+    });
+}

--- a/scripts/js/pw/khala/khalaApi.js
+++ b/scripts/js/pw/khala/khalaApi.js
@@ -1,5 +1,3 @@
-import {Keyring} from "@polkadot/api";
-
 require('dotenv').config();
 const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api');
 
@@ -12,21 +10,12 @@ const davidPrivkey = process.env.DAVID_PRIVKEY;
 const evePrivkey = process.env.EVE_PRIVKEY;
 const endpoint = process.env.ENDPOINT;
 
-const keyring = new Keyring({type: 'sr25519'});
-
-export const alice = keyring.addFromUri(alicePrivkey);
-export const bob = keyring.addFromUri(bobPrivkey);
-export const charlie = keyring.addFromUri(charliePrivkey);
-export const david = keyring.addFromUri(davidPrivkey);
-export const eve = keyring.addFromUri(evePrivkey);
-export const ferdie = keyring.addFromUri(ferdiePrivkey);
-export const overlord = keyring.addFromUri(overlordPrivkey);
-
-export function customAccount(accountUri) {
-    keyring.addFromUri(accountUri)
+async function getAccount(accountUri) {
+    const keyring = new Keyring({type: 'sr25519'});
+    return keyring.addFromUri(accountUri);
 }
 
-export async function getApiConnection() {
+async function getApiConnection() {
     const wsProvider = new WsProvider(endpoint);
     return await ApiPromise.create({
         provider: wsProvider,
@@ -43,4 +32,16 @@ export async function getApiConnection() {
             }
         }
     });
+}
+
+module.exports = {
+    getApiConnection,
+    getAccount,
+    alicePrivkey,
+    bobPrivkey,
+    charliePrivkey,
+    davidPrivkey,
+    evePrivkey,
+    ferdiePrivkey,
+    overlordPrivkey
 }

--- a/scripts/js/pw/khala/khalaApi.js
+++ b/scripts/js/pw/khala/khalaApi.js
@@ -1,7 +1,30 @@
-require('dotenv').config();
-const { ApiPromise, WsProvider } = require('@polkadot/api');
+import {Keyring} from "@polkadot/api";
 
+require('dotenv').config();
+const { ApiPromise, WsProvider, Keyring } = require('@polkadot/api');
+
+const alicePrivkey = process.env.ROOT_PRIVKEY;
+const bobPrivkey = process.env.USER_PRIVKEY;
+const overlordPrivkey = process.env.OVERLORD_PRIVKEY;
+const ferdiePrivkey = process.env.FERDIE_PRIVKEY;
+const charliePrivkey = process.env.CHARLIE_PRIVKEY;
+const davidPrivkey = process.env.DAVID_PRIVKEY;
+const evePrivkey = process.env.EVE_PRIVKEY;
 const endpoint = process.env.ENDPOINT;
+
+const keyring = new Keyring({type: 'sr25519'});
+
+export const alice = keyring.addFromUri(alicePrivkey);
+export const bob = keyring.addFromUri(bobPrivkey);
+export const charlie = keyring.addFromUri(charliePrivkey);
+export const david = keyring.addFromUri(davidPrivkey);
+export const eve = keyring.addFromUri(evePrivkey);
+export const ferdie = keyring.addFromUri(ferdiePrivkey);
+export const overlord = keyring.addFromUri(overlordPrivkey);
+
+export function customAccount(accountUri) {
+    keyring.addFromUri(accountUri)
+}
 
 export async function getApiConnection() {
     const wsProvider = new WsProvider(endpoint);

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "initPhalaWorld": "node ./initKhalaParachain.js",
-    "test": "mocha"
+    "testInitPhalaWorld": "mocha --timeout 9999999 './test/initKhalaParachain.js'"
   },
   "dependencies": {
     "@phala/typedefs": "^0.2.29",
@@ -28,14 +28,14 @@
     "@polkadot/util": "^10.1.1",
     "@polkadot/util-crypto": "^10.1.1",
     "bn.js": "^5.2.1",
+    "chai-as-promised": "^7.1.1",
     "dotenv": "^16.0.1",
     "ethers": "^5.6.9",
+    "find-process": "^1.4.7",
     "graphql": "^16.5.0",
     "graphql-request": "^4.3.0",
     "p-sleep": "^1.1.0",
-    "yargs": "^17.5.1",
-    "chai-as-promised": "^7.1.1",
-    "find-process": "^1.4.7"
+    "yargs": "^17.5.1"
   },
   "standard": {
     "globals": [

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -21,7 +21,8 @@
     "testStartRareOriginOfShellPurchase": "mocha --timeout 9999999 './test/startRareOriginOfShellPurchase.js'",
     "testStartWhitelistOriginShellPurchase": "mocha --timeout 9999999 './test/startWhitelistOriginShellPurchase.js'",
     "testStartOriginShellPreorderProcess": "mocha --timeout 9999999 './test/startOriginShellPreorderProcess.js'",
-    "testStartLastDayOfSale": "mocha --timeout 9999999 './test/status/startLastDayOfSale.js'"
+    "testStartLastDayOfSale": "mocha --timeout 9999999 './test/startLastDayOfSale.js'",
+    "testStartIncubationProcess": "mocha --timeout 9999999 './test/startIncubationProcess.js'"
   },
   "dependencies": {
     "@phala/typedefs": "^0.2.29",

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -16,7 +16,8 @@
   },
   "scripts": {
     "initPhalaWorld": "node ./initKhalaParachain.js",
-    "testInitPhalaWorld": "mocha --timeout 9999999 './test/initKhalaParachain.js'"
+    "testInitPhalaWorld": "mocha --timeout 9999999 './test/initKhalaParachain.js'",
+    "testStartSpiritClaimProcess": "mocha --timeout 9999999 './test/startSpiritClaimProcess.js'"
   },
   "dependencies": {
     "@phala/typedefs": "^0.2.29",

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -23,7 +23,8 @@
     "testStartOriginShellPreorderProcess": "mocha --timeout 9999999 './test/startOriginShellPreorderProcess.js'",
     "testStartLastDayOfSale": "mocha --timeout 9999999 './test/startLastDayOfSale.js'",
     "testStartIncubationProcess": "mocha --timeout 9999999 './test/startIncubationProcess.js'",
-    "testStartHatchingOriginOfShells": "mocha --timeout 9999999 './test/startHatchingOriginOfShells.js'"
+    "testStartHatchingOriginOfShells": "mocha --timeout 9999999 './test/startHatchingOriginOfShells.js'",
+    "testSimulateNftMarketSales": "mocha --timeout 9999999 './test/simulateNftMarketSales.js'"
   },
   "dependencies": {
     "@phala/typedefs": "^0.2.29",

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "pw-scripts",
+  "version": "1.0.0",
+  "main": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/chai": "^4.3.1",
+    "@types/chai-as-promised": "^7.1.5",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^17.0.35",
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
+  },
+  "mocha": {
+    "timeout": 9999999
+  },
+  "scripts": {
+    "initPhalaWorld": "node ./initKhalaParachain.js",
+    "test": "mocha"
+  },
+  "dependencies": {
+    "@phala/typedefs": "^0.2.29",
+    "@polkadot/api": "^8.13.1",
+    "@polkadot/api-augment": "^8.13.1",
+    "@polkadot/keyring": "^10.1.1",
+    "@polkadot/rpc-provider": "^8.13.1",
+    "@polkadot/types": "^8.13.1",
+    "@polkadot/util": "^10.1.1",
+    "@polkadot/util-crypto": "^10.1.1",
+    "bn.js": "^5.2.1",
+    "dotenv": "^16.0.1",
+    "ethers": "^5.6.9",
+    "graphql": "^16.5.0",
+    "graphql-request": "^4.3.0",
+    "p-sleep": "^1.1.0",
+    "yargs": "^17.5.1",
+    "chai-as-promised": "^7.1.1",
+    "find-process": "^1.4.7"
+  },
+  "standard": {
+    "globals": [
+      "it",
+      "assert",
+      "beforeEach",
+      "afterEach",
+      "describe",
+      "contract",
+      "artifacts"
+    ]
+  },
+  "resolutions": {
+    "simple-get": "^4.0.1"
+  }
+}

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -22,7 +22,8 @@
     "testStartWhitelistOriginShellPurchase": "mocha --timeout 9999999 './test/startWhitelistOriginShellPurchase.js'",
     "testStartOriginShellPreorderProcess": "mocha --timeout 9999999 './test/startOriginShellPreorderProcess.js'",
     "testStartLastDayOfSale": "mocha --timeout 9999999 './test/startLastDayOfSale.js'",
-    "testStartIncubationProcess": "mocha --timeout 9999999 './test/startIncubationProcess.js'"
+    "testStartIncubationProcess": "mocha --timeout 9999999 './test/startIncubationProcess.js'",
+    "testStartHatchingOriginOfShells": "mocha --timeout 9999999 './test/startHatchingOriginOfShells.js'"
   },
   "dependencies": {
     "@phala/typedefs": "^0.2.29",

--- a/scripts/js/pw/package.json
+++ b/scripts/js/pw/package.json
@@ -17,7 +17,11 @@
   "scripts": {
     "initPhalaWorld": "node ./initKhalaParachain.js",
     "testInitPhalaWorld": "mocha --timeout 9999999 './test/initKhalaParachain.js'",
-    "testStartSpiritClaimProcess": "mocha --timeout 9999999 './test/startSpiritClaimProcess.js'"
+    "testStartSpiritClaimProcess": "mocha --timeout 9999999 './test/startSpiritClaimProcess.js'",
+    "testStartRareOriginOfShellPurchase": "mocha --timeout 9999999 './test/startRareOriginOfShellPurchase.js'",
+    "testStartWhitelistOriginShellPurchase": "mocha --timeout 9999999 './test/startWhitelistOriginShellPurchase.js'",
+    "testStartOriginShellPreorderProcess": "mocha --timeout 9999999 './test/startOriginShellPreorderProcess.js'",
+    "testStartLastDayOfSale": "mocha --timeout 9999999 './test/status/startLastDayOfSale.js'"
   },
   "dependencies": {
     "@phala/typedefs": "^0.2.29",

--- a/scripts/js/pw/test/initKhalaParachain.js
+++ b/scripts/js/pw/test/initKhalaParachain.js
@@ -1,0 +1,61 @@
+const expect = require('chai');
+const { getApiConnection, getAccount, alicePrivkey, bobPrivkey, charliePrivkey, davidPrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey } = require('../khala/khalaApi');
+const { transferPha, setOverlordAccount, pwCreateCollection, initializePhalaWorldClock, initializeRarityTypeCounts } = require('../util/tx');
+const { token } = require("../pwUtils");
+
+describe("Initialize Khala Parachain", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+
+    // Send PHA to Account from Alice
+    it(`Send PHA to userAccounts`, async () => {
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        overlord = await getAccount(overlordPrivkey);
+        const userAccounts = [overlord, bob, charlie, david, eve, ferdie];
+        await transferPha(api, alice, userAccounts, token(20_000));
+    });
+    // Set Overlord account
+    it(`Set Overlord Account`, async () => {
+        alice = await getAccount(alicePrivkey);
+        overlord = await getAccount(overlordPrivkey);
+        await setOverlordAccount(api, alice, overlord);
+    });
+    // Initialize PhalaWorld
+    it(`Initialize PhalaWorld Clock`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await initializePhalaWorldClock(api, overlord);
+    });
+    // Create and Set PhalaWorld Collections
+    it(`Create/Set Spirits Collection ID`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await pwCreateCollection(api, overlord, 'PhalaWorld Spirits Collection', null, 'PWSPRT', 'spirit');
+    });
+    it(`Create/Set Origin of Shells Collection ID`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await pwCreateCollection(api, overlord, 'PhalaWorld Origin of Shells Collection', null, 'PWOAS', 'originOfShell');
+    });
+    it(`Create/Set Shells Collection ID`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await pwCreateCollection(api, overlord, 'PhalaWorld Shells Collection', null, 'PWSHL', 'shell');
+    });
+    it(`Create/Set Shell Parts Collection ID`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await pwCreateCollection(api, overlord, 'PhalaWorld Shell Parts Collection', null, 'PWPRT', 'shellParts');
+    });
+    it(`Initialize PhalaWorld Rarity Inventory Count`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await initializeRarityTypeCounts(api, overlord);
+    });
+    after(() => {
+        api.disconnect();
+    });
+})

--- a/scripts/js/pw/test/simulateNftMarketSales.js
+++ b/scripts/js/pw/test/simulateNftMarketSales.js
@@ -1,0 +1,98 @@
+const { getApiConnection, getAccount, alicePrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey, bobPrivkey,
+    charliePrivkey, davidPrivkey
+} = require('../khala/khalaApi');
+const {setIncubationProcessStatus, hatchOriginOfShell, listNft, buyNft, sendNftToOwner, makeOfferOnNft,
+    withdrawOfferOnNft, unlistNft, acceptOfferOnNft, failToSendNonTransferableNft
+} = require("../util/tx");
+const { getOwnedNftsInCollection, getShellCollectionId, getShellPartsCollectionId} = require("../util/fetch");
+const {getNonTransferableNft} = require("../util/helpers");
+
+describe("Simulate NFT Market Sales", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    it(`Alice Lists and Sells Shell NFT to Bob`, async () => {
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey)
+        const shellCollectionId = await getShellCollectionId(api);
+        expect(
+            shellCollectionId.isSome,
+            `Error: Shell Collection ID is not set`
+        ).to.be.true;
+        const nfts = await getOwnedNftsInCollection(api, alice, shellCollectionId.unwrap().toNumber());
+        expect(
+            nfts.length > 0,
+            `Error: Alice does not own a Shell NFT`
+        ).to.be.true;
+        const nftId = nfts[0];
+        await listNft(api, alice, shellCollectionId.unwrap(), nftId, 1000, null);
+        await buyNft(api, bob, shellCollectionId.unwrap(), nftId, 1000);
+    });
+    let shellPartNftId;
+    it(`Bob Sends Shell Part NFT to Self and Lists Shell Part NFT`, async () => {
+        bob = await getAccount(bobPrivkey);
+        const shellPartsCollectionId = await getShellPartsCollectionId(api);
+        expect(
+            shellPartsCollectionId.isSome,
+            `Error: Shell Parts Collection ID is not set`
+        ).to.be.true;
+        const nfts = await getOwnedNftsInCollection(api, bob, shellPartsCollectionId.unwrap().toNumber());
+        expect(
+            nfts.length > 0,
+            `Error: Bob does not own a Shell Parts NFT`
+        ).to.be.true;
+        shellPartNftId = nfts[0];
+        await sendNftToOwner(api, bob, shellPartsCollectionId, shellPartNftId, bob);
+        await listNft(api, bob, shellPartsCollectionId, shellPartNftId, 50, null);
+    });
+    it(`Charlie & David Make Offers on Bob's Shell Part Listed Then Charlie Withdraws Offer`, async () => {
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        const shellPartsCollectionId = await getShellPartsCollectionId(api);
+        expect(
+            shellPartsCollectionId.isSome,
+            `Error: Shell Parts Collection ID is not set`
+        ).to.be.true;
+        await makeOfferOnNft(api, charlie, shellPartsCollectionId.unwrap(), shellPartNftId, 10, null);
+        await makeOfferOnNft(api, david, shellPartsCollectionId.unwrap(), shellPartNftId, 45, 50);
+        await withdrawOfferOnNft(api, charlie, shellPartsCollectionId.unwrap(), shellPartNftId);
+    });
+    it(`Bob Unlists Shell Part NFT Then Accepts David's Offer`, async () => {
+        david = await getAccount(davidPrivkey);
+        bob = await getAccount(bobPrivkey);
+        const shellPartsCollectionId = await getShellPartsCollectionId(api);
+        expect(
+            shellPartsCollectionId.isSome,
+            `Error: Shell Parts Collection ID is not set`
+        ).to.be.true;
+        await unlistNft(api, bob, shellPartsCollectionId.unwrap(), shellPartNftId);
+        await acceptOfferOnNft(api, bob, shellPartsCollectionId.unwrap(), shellPartNftId, david);
+    });
+    it(`Bob Cannot Send Non-Transferable Shell Part`, async () => {
+        bob = await getAccount(bobPrivkey);
+        const shellPartsCollectionId = await getShellPartsCollectionId(api);
+        expect(
+            shellPartsCollectionId.isSome,
+            `Error: Shell Parts Collection ID is not set`
+        ).to.be.true;
+        const nfts = await getOwnedNftsInCollection(api, bob, shellPartsCollectionId.unwrap().toNumber());
+        expect(
+            nfts.length > 0,
+            `Error: Bob does not own a Shell Parts NFT`
+        ).to.be.true;
+        const nftId = await getNonTransferableNft(api, shellPartsCollectionId.unwrap(), nfts);
+        expect(
+            nftId > 0,
+            `Error: Did not find a non-transferable Shell Part NFT`
+        ).to.be.true;
+        await failToSendNonTransferableNft(api, bob, shellPartsCollectionId.unwrap(), nftId, bob);
+    });
+
+    after(() => {
+        api.disconnect();
+    });
+});
+

--- a/scripts/js/pw/test/startHatchingOriginOfShells.js
+++ b/scripts/js/pw/test/startHatchingOriginOfShells.js
@@ -1,0 +1,33 @@
+const { getApiConnection, getAccount, alicePrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey, bobPrivkey,
+    charliePrivkey, davidPrivkey
+} = require('../khala/khalaApi');
+const { setIncubationProcessStatus, hatchOriginOfShell } = require('../util/tx');
+
+describe("Start Shell NFT Hatching Process", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    it(`Disable Incubation Process`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setIncubationProcessStatus(api, overlord, false);
+    });
+    it(`Start Hatching Origin of Shells into Shell NFTs`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const originOfShellsOwners = [alice, bob, charlie, david, eve, ferdie];
+        // Set chosen part for NFT ID 0
+        await hatchOriginOfShell(api, overlord, originOfShellsOwners);
+    });
+
+    after(() => {
+        api.disconnect();
+    });
+});

--- a/scripts/js/pw/test/startIncubationProcess.js
+++ b/scripts/js/pw/test/startIncubationProcess.js
@@ -62,87 +62,274 @@ describe("Start Origin of Shell Incubation Process", () => {
     it(`Set Origin of Shell Chosen Parts`, async () => {
         overlord = await getAccount(overlordPrivkey);
         // TODO: Generate parts helper function
-        const jacketChosenPart = {
-            'parts': {
+        const CyborgChosenParts = {
+            "parts": {
+                "weapon":  {
+                    "shell_part": {
+                        "name": "Weapon",
+                        "metadata": null,
+                        "layer": 0,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    "sub_parts": [
+                        {
+                            "name": "lightsaber",
+                            "rarity": "Normal",
+                            "career": "RoboWarrior",
+                            "style": "Sg01",
+                            "layer": 19,
+                            "metadata": "pw://weapon/lighsaber",
+                            "tradeable": true,
+                        },
+                        {
+                            "name": "Sniper Rifle",
+                            "rarity": "Rare",
+                            "career": "RoboWarrior",
+                            "style": "Sp01",
+                            "layer": 20,
+                            "metadata": "pw://weapon/sniper-rifle",
+                            "tradeable": true,
+                        },
+                    ]
+                },
+                "body": {
+                    "shell_part": {
+                        "name": "Body",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA"],
+                        "layer": 0,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    "sub_parts": [
+                        {
+                            "name": "Short Hair",
+                            "style": "Sg01",
+                            "rarity": "Normal",
+                            "metadata": "pw://body/hair/short-hair",
+                            "layer": 2,
+                            'x': 0,
+                            'y': 0,
+                        },
+                        {
+                            "name": "Human Eyes",
+                            "rarity": "Normal",
+                            "metadata": "pw://body/eyes/human-eyes",
+                            "layer": 4,
+                            'x': 0,
+                            'y': 0,
+                        },
+                        {
+                            "name": "Male Head 01",
+                            "style": "Skin01",
+                            "rarity": "Normal",
+                            "metadata": "pw://body/head/male-head-01",
+                            "layer": 6,
+                            'x': 0,
+                            'y': 0,
+                        },
+                        {
+                            "name": "Male Body 01",
+                            "style": "Skin01",
+                            "rarity": "Normal",
+                            "metadata": "pw://body/body/male-body-01",
+                            "layer": 16,
+                            'x': 0,
+                            'y': 0,
+                        },
+                    ],
+                },
+                "jaw": {
+                    "shell_part": {
+                        "name": "Cyborg Jaw(Neck)",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA"],
+                        "style": "Me01",
+                        "metadata": "pw://jaw",
+                        "layer": 3,
+                        'x': 0,
+                        'y': 0,
+                        "tradeable": true,
+                    },
+                },
+                "tattoo": {
+                    "shell_part": {
+                        "name": "Cyberpsychosis Tatoo",
+                        "rarity": "Epic",
+                        "race": "Cyborg",
+                        "sizes": ["MA"],
+                        "style": "Sp01",
+                        "metadata": "pw://tattoo",
+                        "layer": 5,
+                        'x': 0,
+                        'y': 0,
+                        "tradeable": true,
+                    },
+                },
                 "jacket": {
-                    'shell_part': {
-                        'name': "jacket",
-                        'rarity': 'Magic',
-                        'metadata': null,
-                        'layer': 0,
+                    "shell_part": {
+                        "name": "Jacket",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA", "MB"],
+                        "layer": 0,
                         'x': 0,
                         'y': 0,
+                        "tradeable": true,
                     },
-                    'sub_parts': [
+                    "sub_parts": [
                         {
-                            'name': "jacket-details",
-                            'rarity': 'Legendary',
-                            'metadata': "ar://jacket-details-uri",
-                            'layer': 0,
+                            "name": "White Buckle",
+                            "rarity": "Normal",
+                            "style": "Sg01",
+                            "metadata": "pw://jacket/jacket_details",
+                            "layer": 7,
                             'x': 0,
-                            'y': 0
+                            'y': 0,
                         },
                         {
-                            'name': "jacket-hat",
-                            'rarity': 'Magic',
-                            'metadata': "ar://jacket-hat-uri",
-                            'layer': 0,
+                            "name": "Solid Jacket",
+                            "rarity": "Normal",
+                            "style": "Sg01",
+                            "metadata": "pw://jacket/jacket",
+                            "layer": 8,
                             'x': 0,
-                            'y': 0
+                            'y': 0,
                         },
                         {
-                            'name': "jacket",
-                            'rarity': 'Prime',
-                            'metadata': "ar://jacket-uri",
-                            'layer': 0,
+                            "name": "Lightspeed Hood",
+                            "rarity": "Legend",
+                            "style": "Sp01",
+                            "metadata": "pw://jacket/hood",
+                            "layer": 17,
                             'x': 0,
-                            'y': 0
-                        }
+                            'y': 0,
+                        },
+                        {
+                            "name": "Solid Jacket",
+                            "rarity": "Normal",
+                            "style": "Sg01",
+                            "metadata": "pw://jacket/jacketun",
+                            "layer": 18,
+                            'x': 0,
+                            'y': 0,
+                        },
                     ],
                 },
-                't_shirt': {
-                    'shell_part': {
-                        'name': 't_shirt',
-                        'rarity': 'Prime',
-                        'metadata': "ar://t-shirt-uri",
-                        'layer': 0,
+                "bionic_arm": {
+                    "shell_part": {
+                        "name": "Black Bionic Arm",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA", "MB"],
+                        "style": "Sg01",
+                        "metadata": "pw://bionic_arm",
+                        "layer": 9,
                         'x': 0,
                         'y': 0,
+                        "tradeable": true,
                     },
-                    'sub_parts': null,
                 },
-                'shoes': {
-                    'shell_part': {
-                        'name': "shoes",
-                        'rarity': 'Prime',
-                        'metadata': null,
-                        'layer': 0,
+                "shirt": {
+                    "shell_part": {
+                        "name": "Cyborg's symbol T-Shirt",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA", "MB"],
+                        "style": "Sg07",
+                        "metadata": "pw://shirt",
+                        "layer": 10,
                         'x': 0,
                         'y': 0,
+                        "tradeable": true,
                     },
-                    'sub_parts': [
+                },
+                "shorts": {
+                    "shell_part": {
+                        "name": "Shorts",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA", "MB"],
+                        "metadata": null,
+                        "layer": 0,
+                        'x': 0,
+                        'y': 0,
+                        "tradeable": true,
+                    },
+                    "sub_parts": [
                         {
-                            'name': "shoes-details",
-                            'rarity': 'Prime',
-                            'metadata': "ar://shoes-details-uri",
-                            'layer': 0,
+                            "name": "Black Buckle",
+                            "rarity": "Normal",
+                            "style": "Sg01",
+                            "metadata": "pw://shorts/shorts-details",
+                            "layer": 11,
                             'x': 0,
-                            'y': 0
+                            'y': 0,
                         },
                         {
-                            'name': "shoes",
-                            'rarity': 'Prime',
-                            'metadata': "ar://shoes-uri",
-                            'layer': 0,
+                            "name": "Solid Shorts",
+                            "rarity": "Normal",
+                            "style": "Sg01",
+                            "metadata": "pw://shorts/shorts",
+                            "layer": 12,
                             'x': 0,
-                            'y': 0
-                        }
+                            'y': 0,
+                        },
                     ],
-                }
-            }
+                },
+                "feet": {
+                    "shell_part": {
+                        "name": "Feet",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA", "MB"],
+                        "layer": 0,
+                        'x': 0,
+                        'y': 0,
+                        "tradeable": true,
+                    },
+                    "sub_parts": [
+                        {
+                            "name": "Solid Shorts Buckle",
+                            "rarity": "Normal",
+                            "style": "Sg04",
+                            "metadata": "pw://feet/shoes-ribbon",
+                            "layer": 13,
+                            'x': 0,
+                            'y': 0,
+                        },
+                        {
+                            "name": "Black Fade Shorts",
+                            "rarity": "Epic",
+                            "style": "Gc02",
+                            "metadata": "pw://feet/shoes",
+                            "layer": 14,
+                            'x': 0,
+                            'y': 0,
+                        }
+                    ]
+                },
+                "bionic_leg": {
+                    "shell_part": {
+                        "name": "Black Bionic Leg",
+                        "rarity": "Normal",
+                        "race": "Cyborg",
+                        "sizes": ["MA", "MB"],
+                        "style": "Sg01",
+                        "metadata": "pw://bionic_leg",
+                        "layer": 15,
+                        'x': 0,
+                        'y': 0,
+                        "tradeable": true,
+                    },
+                },
+            },
         };
         // Set chosen part for NFT ID 0
-        await setOriginOfShellChosenParts(api, overlord, 1, 0, jacketChosenPart);
+        await setOriginOfShellChosenParts(api, overlord, 1, 0, CyborgChosenParts);
     });
 
     after(() => {

--- a/scripts/js/pw/test/startIncubationProcess.js
+++ b/scripts/js/pw/test/startIncubationProcess.js
@@ -1,0 +1,151 @@
+const { getApiConnection, getAccount, alicePrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey, bobPrivkey,
+    charliePrivkey, davidPrivkey
+} = require('../khala/khalaApi');
+const { setIncubationProcessStatus, initializeAccountsIncubationProcess, simulateFeeding, mintChosenPreorders, setOriginOfShellChosenParts
+} = require('../util/tx');
+const { getTopNFed } = require('../util/helpers');
+const { getEra } = require('../util/fetch');
+
+describe("Start Origin of Shell Incubation Process", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    // it(`Enable Incubation Process`, async () => {
+    //     overlord = await getAccount(overlordPrivkey);
+    //     await setIncubationProcessStatus(api, overlord, true);
+    // });
+    // it(`Initialize Accounts Incubation Process`, async () => {
+    //     alice = await getAccount(alicePrivkey);
+    //     bob = await getAccount(bobPrivkey);
+    //     charlie = await getAccount(charliePrivkey);
+    //     david = await getAccount(davidPrivkey);
+    //     eve = await getAccount(evePrivkey);
+    //     ferdie = await getAccount(ferdiePrivkey);
+    //     const addresses = [alice, bob, charlie, david, eve, ferdie];
+    //     await initializeAccountsIncubationProcess(api, addresses);
+    // });
+    // it(`Simulate Feeding between Accounts`, async () => {
+    //     alice = await getAccount(alicePrivkey);
+    //     bob = await getAccount(bobPrivkey);
+    //     charlie = await getAccount(charliePrivkey);
+    //     david = await getAccount(davidPrivkey);
+    //     eve = await getAccount(evePrivkey);
+    //     ferdie = await getAccount(ferdiePrivkey);
+    //     const accountFeedSimulation = [
+    //         {'account': alice, 'feedTo': 0},
+    //         {'account': bob, 'feedTo': 0},
+    //         {'account': charlie, 'feedTo': 1},
+    //         {'account': david, 'feedTo': 2},
+    //         {'account': eve, 'feedTo': 3},
+    //         {'account': ferdie, 'feedTo': 4},
+    //         {'account': alice, 'feedTo': 5},
+    //         {'account': bob, 'feedTo': 1},
+    //         {'account': charlie, 'feedTo': 3},
+    //         {'account': david, 'feedTo': 0},
+    //         {'account': eve, 'feedTo': 1},
+    //         {'account': ferdie, 'feedTo': 4},
+    //     ];
+    //     await simulateFeeding(api, accountFeedSimulation);
+    // });
+    it(`Get Top 6 Origin of Shells Fed`, async () => {
+        const currentEra = await getEra(api);
+        const top6Fed = await getTopNFed(api, currentEra, 6);
+        let i = 0;
+        for (const originOfShellCollectionIdNftId in top6Fed) {
+            console.log(`\t[${i}]: ${originOfShellCollectionIdNftId}`);
+            i++;
+        }
+    });
+    it(`Set Origin of Shell Chosen Parts`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        // TODO: Generate parts helper function
+        const jacketChosenPart = {
+            'parts': {
+                "jacket": {
+                    'shell_part': {
+                        'name': "jacket",
+                        'rarity': 'Magic',
+                        'metadata': null,
+                        'layer': 0,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    'sub_parts': [
+                        {
+                            'name': "jacket-details",
+                            'rarity': 'Legendary',
+                            'metadata': "ar://jacket-details-uri",
+                            'layer': 0,
+                            'x': 0,
+                            'y': 0
+                        },
+                        {
+                            'name': "jacket-hat",
+                            'rarity': 'Magic',
+                            'metadata': "ar://jacket-hat-uri",
+                            'layer': 0,
+                            'x': 0,
+                            'y': 0
+                        },
+                        {
+                            'name': "jacket",
+                            'rarity': 'Prime',
+                            'metadata': "ar://jacket-uri",
+                            'layer': 0,
+                            'x': 0,
+                            'y': 0
+                        }
+                    ],
+                },
+                't_shirt': {
+                    'shell_part': {
+                        'name': 't_shirt',
+                        'rarity': 'Prime',
+                        'metadata': "ar://t-shirt-uri",
+                        'layer': 0,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    'sub_parts': null,
+                },
+                'shoes': {
+                    'shell_part': {
+                        'name': "shoes",
+                        'rarity': 'Prime',
+                        'metadata': null,
+                        'layer': 0,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    'sub_parts': [
+                        {
+                            'name': "shoes-details",
+                            'rarity': 'Prime',
+                            'metadata': "ar://shoes-details-uri",
+                            'layer': 0,
+                            'x': 0,
+                            'y': 0
+                        },
+                        {
+                            'name': "shoes",
+                            'rarity': 'Prime',
+                            'metadata': "ar://shoes-uri",
+                            'layer': 0,
+                            'x': 0,
+                            'y': 0
+                        }
+                    ],
+                }
+            }
+        };
+        // Set chosen part for NFT ID 0
+        await setOriginOfShellChosenParts(api, overlord, 1, 0, jacketChosenPart);
+    });
+
+    after(() => {
+        api.disconnect();
+    });
+});

--- a/scripts/js/pw/test/startIncubationProcess.js
+++ b/scripts/js/pw/test/startIncubationProcess.js
@@ -13,43 +13,43 @@ describe("Start Origin of Shell Incubation Process", () => {
     before(async () => {
         api = await getApiConnection();
     });
-    // it(`Enable Incubation Process`, async () => {
-    //     overlord = await getAccount(overlordPrivkey);
-    //     await setIncubationProcessStatus(api, overlord, true);
-    // });
-    // it(`Initialize Accounts Incubation Process`, async () => {
-    //     alice = await getAccount(alicePrivkey);
-    //     bob = await getAccount(bobPrivkey);
-    //     charlie = await getAccount(charliePrivkey);
-    //     david = await getAccount(davidPrivkey);
-    //     eve = await getAccount(evePrivkey);
-    //     ferdie = await getAccount(ferdiePrivkey);
-    //     const addresses = [alice, bob, charlie, david, eve, ferdie];
-    //     await initializeAccountsIncubationProcess(api, addresses);
-    // });
-    // it(`Simulate Feeding between Accounts`, async () => {
-    //     alice = await getAccount(alicePrivkey);
-    //     bob = await getAccount(bobPrivkey);
-    //     charlie = await getAccount(charliePrivkey);
-    //     david = await getAccount(davidPrivkey);
-    //     eve = await getAccount(evePrivkey);
-    //     ferdie = await getAccount(ferdiePrivkey);
-    //     const accountFeedSimulation = [
-    //         {'account': alice, 'feedTo': 0},
-    //         {'account': bob, 'feedTo': 0},
-    //         {'account': charlie, 'feedTo': 1},
-    //         {'account': david, 'feedTo': 2},
-    //         {'account': eve, 'feedTo': 3},
-    //         {'account': ferdie, 'feedTo': 4},
-    //         {'account': alice, 'feedTo': 5},
-    //         {'account': bob, 'feedTo': 1},
-    //         {'account': charlie, 'feedTo': 3},
-    //         {'account': david, 'feedTo': 0},
-    //         {'account': eve, 'feedTo': 1},
-    //         {'account': ferdie, 'feedTo': 4},
-    //     ];
-    //     await simulateFeeding(api, accountFeedSimulation);
-    // });
+    it(`Enable Incubation Process`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setIncubationProcessStatus(api, overlord, true);
+    });
+    it(`Initialize Accounts Incubation Process`, async () => {
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const addresses = [alice, bob, charlie, david, eve, ferdie];
+        await initializeAccountsIncubationProcess(api, addresses);
+    });
+    it(`Simulate Feeding between Accounts`, async () => {
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const accountFeedSimulation = [
+            {'account': alice, 'feedTo': 0},
+            {'account': bob, 'feedTo': 0},
+            {'account': charlie, 'feedTo': 1},
+            {'account': david, 'feedTo': 2},
+            {'account': eve, 'feedTo': 3},
+            {'account': ferdie, 'feedTo': 4},
+            {'account': alice, 'feedTo': 5},
+            {'account': bob, 'feedTo': 1},
+            {'account': charlie, 'feedTo': 3},
+            {'account': david, 'feedTo': 0},
+            {'account': eve, 'feedTo': 1},
+            {'account': ferdie, 'feedTo': 4},
+        ];
+        await simulateFeeding(api, accountFeedSimulation);
+    });
     it(`Get Top 6 Origin of Shells Fed`, async () => {
         const currentEra = await getEra(api);
         const top6Fed = await getTopNFed(api, currentEra, 6);

--- a/scripts/js/pw/test/startLastDayOfSale.js
+++ b/scripts/js/pw/test/startLastDayOfSale.js
@@ -1,0 +1,52 @@
+const { getApiConnection, getAccount, alicePrivkey, bobPrivkey, charliePrivkey, davidPrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey } = require('../khala/khalaApi');
+const { setStatusType, userPreorderOriginOfShell, mintChosenPreorders, refundNotChosenPreorders } = require('../util/tx');
+
+describe("Start Last Day of Sale Preorder Process", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    // TODO: Query if PreorderOriginOfShells is enabled
+    it(`Enable LastDayOfSale StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'LastDayOfSale', true);
+    });
+    it(`Last Day of Sale Preorder Prime Origin of Shells`, async () => {
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const userAccountLastDayPreordersOriginOfShellInfo = [
+            {'account': alice, 'race': 'AISpectre', 'career': 'Web3Monk'},
+            {'account': ferdie, 'race': 'Pandroid', 'career': 'RoboWarrior'},
+            {'account': eve, 'race': 'XGene', 'career': 'TradeNegotiator'},
+            {'account': bob, 'race': 'Cyborg', 'career': 'HackerWizard'},
+            {'account': charlie, 'race': 'XGene', 'career': 'RoboWarrior'},
+            {'account': david, 'race': 'Cyborg', 'career': 'TradeNegotiator'}
+        ]
+        await userPreorderOriginOfShell(api, userAccountLastDayPreordersOriginOfShellInfo);
+    });
+    it(`Disable LastDayOfSale StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'LastDayOfSale', false);
+    });
+    it(`Mint Chosen Preorders`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        // TODO: Maybe query the preorders & randomly choose instead
+        const chosenPreorders = [2, 3, 4, 5];
+        await mintChosenPreorders(api, overlord, chosenPreorders);
+    });
+    it(`Refund Not Chosen Preorders`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        // TODO: Maybe query the preorders & randomly choose instead
+        const notChosenPreorders = [0, 1];
+        await refundNotChosenPreorders(api, overlord, notChosenPreorders);
+    });
+    after(() => {
+        api.disconnect();
+    });
+});

--- a/scripts/js/pw/test/startOriginShellPreorderProcess.js
+++ b/scripts/js/pw/test/startOriginShellPreorderProcess.js
@@ -1,0 +1,53 @@
+const { getApiConnection, getAccount, alicePrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey } = require('../khala/khalaApi');
+const { setStatusType, updateRarityTypeCounts, userPreorderOriginOfShell, mintChosenPreorders, refundNotChosenPreorders } = require('../util/tx');
+
+describe("Start Origin of Shells Preorder Process", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    it(`Disable PurchasePrimeOriginOfShells StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'PurchasePrimeOriginOfShells', false);
+    });
+    it(`Update the Rarity Inventory Count`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await updateRarityTypeCounts(api, overlord, 'Prime', 900, 50);
+    });
+    it(`Enable PreorderOriginOfShells StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'PreorderOriginOfShells', true);
+    });
+    it(`Preorder Prime Origin of Shells`, async () => {
+        alice = await getAccount(alicePrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const userAccountPreordersOriginOfShellInfo = [
+            {'account': alice, 'race': 'AISpectre', 'career': 'Web3Monk'},
+            {'account': ferdie, 'race': 'Pandroid', 'career': 'RoboWarrior'},
+            {'account': eve, 'race': 'XGene', 'career': 'TradeNegotiator'}
+        ];
+        await userPreorderOriginOfShell(api, userAccountPreordersOriginOfShellInfo);
+    });
+    it(`Disable PreorderOriginOfShells StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'PreorderOriginOfShells', false);
+    });
+    it(`Mint Chosen Preorders`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        // TODO: Maybe query the preorders & randomly choose instead
+        const chosenPreorders = [0, 1];
+        await mintChosenPreorders(api, overlord, chosenPreorders);
+    });
+    it(`Refund Not Chosen Preorders`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        // TODO: Maybe query the preorders & randomly choose instead
+        const notChosenPreorders = [2];
+        await refundNotChosenPreorders(api, overlord, notChosenPreorders);
+    });
+    after(() => {
+        api.disconnect();
+    });
+});

--- a/scripts/js/pw/test/startRareOriginOfShellPurchase.js
+++ b/scripts/js/pw/test/startRareOriginOfShellPurchase.js
@@ -1,0 +1,34 @@
+const { getApiConnection, getAccount, bobPrivkey, charliePrivkey, davidPrivkey, overlordPrivkey } = require('../khala/khalaApi');
+const { addOriginOfShellsMetadata, setStatusType, usersPurchaseRareOriginOfShells } = require('../util/tx');
+
+describe("Start Rare Origin of Shells Purchase", () => {
+    let api;
+    let bob, charlie, david, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    it(`Add Origin of Shells RarityType Metadata`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        const originOfShellsMetadataArr = [['Cyborg', 'ar://BS-NUyJWDKJ-CwTYLWZz6TpG0CbWVKUAXvdPQu-KimI'], ['AISpectre', 'ar://KR3ZIIcc_Q6_47sibLOJ5YoFwJZqT6C7aJkkUYbUWbU'], ['Pandroid', 'ar://BS-NUyJWDKJ-CwTYLWZz6TpG0CbWVKUAXvdPQu-KimI'], ['XGene', 'ar://IzOXT_pER7487_RBpzGNOKNBGnDouN1mOcPXojE_Das']];
+        await addOriginOfShellsMetadata(api, overlord, originOfShellsMetadataArr);
+    });
+    it(`Enable PurchaseRareOriginOfShells StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'PurchaseRareOriginOfShells', true);
+    });
+    it(`Simulate Rare Origin of Shell User Purchases`, async () => {
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        const userAccountsRareOriginOfShellInfo = [
+            {'account': bob, 'rarity': 'Legendary', 'race': 'Cyborg', 'career': 'HackerWizard', 'amount': 15_001},
+            {'account': charlie, 'rarity': 'Magic', 'race': 'Pandroid', 'career': 'RoboWarrior', 'amount': 10_001},
+            {'account': david, 'rarity': 'Magic', 'race': 'XGene', 'career': 'TradeNegotiator', 'amount': 10_001}
+        ];
+        await usersPurchaseRareOriginOfShells(api, userAccountsRareOriginOfShellInfo);
+    });
+    after(() => {
+        api.disconnect();
+    });
+})

--- a/scripts/js/pw/test/startSpiritClaimProcess.js
+++ b/scripts/js/pw/test/startSpiritClaimProcess.js
@@ -1,0 +1,32 @@
+const { getApiConnection, getAccount, alicePrivkey, bobPrivkey, charliePrivkey, davidPrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey } = require('../khala/khalaApi');
+const { addSpiritMetadata, setStatusType, usersClaimSpirits} = require('../util/tx');
+
+describe("Start Spirit Claim Process", () => {
+    let api;
+    let alice, bob, charlie, david, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    it(`Add Spirits Metadata`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await addSpiritMetadata(api, overlord, "ar://Q6N5cKjuLzihuiyVlpU-ANUM5ffKLwYYACKFN4mbNuw");
+    });
+    it(`Enable ClaimSpirits StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'ClaimSpirits', true);
+    });
+    it(`Simulate Users' Spirit Claims`, async () => {
+        alice = await getAccount(alicePrivkey);
+        bob = await getAccount(bobPrivkey);
+        charlie = await getAccount(charliePrivkey);
+        david = await getAccount(davidPrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const userAccounts = [alice, bob, charlie, david, eve, ferdie];
+        await usersClaimSpirits(api, userAccounts);
+    });
+    after(() => {
+        api.disconnect();
+    });
+})

--- a/scripts/js/pw/test/startWhitelistOriginShellPurchase.js
+++ b/scripts/js/pw/test/startWhitelistOriginShellPurchase.js
@@ -1,0 +1,33 @@
+const { getApiConnection, getAccount, alicePrivkey, evePrivkey, ferdiePrivkey, overlordPrivkey } = require('../khala/khalaApi');
+const { usersPurchaseWhitelistOriginOfShells, setStatusType} = require('../util/tx');
+const { createWhitelistMessage } = require('../util/helpers');
+
+describe("Start Origin of Shell Whitelist Purchase Process", () => {
+    let api;
+    let alice, eve, ferdie, overlord;
+
+    before(async () => {
+        api = await getApiConnection();
+    });
+    it(`Enable PurchasePrimeOriginOfShells StatusType`, async () => {
+        overlord = await getAccount(overlordPrivkey);
+        await setStatusType(api, overlord, 'PurchasePrimeOriginOfShells', true);
+    });
+    it(`Simulate Whitelist Origin of Shell Purchases`, async () => {
+        alice = await getAccount(alicePrivkey);
+        eve = await getAccount(evePrivkey);
+        ferdie = await getAccount(ferdiePrivkey);
+        const aliceWlMessage = await createWhitelistMessage(api, 'OverlordMessage', overlord, alice);
+        const ferdieWlMessage = await createWhitelistMessage(api, 'OverlordMessage', overlord, ferdie);
+        const eveWlMessage = await createWhitelistMessage(api, 'OverlordMessage', overlord, eve);
+        const userAccountsWhitelistOriginOfShellInfo = [
+            {'account': alice, 'whitelistMessage': aliceWlMessage, 'race': 'AISpectre', 'career': 'HardwareDruid'},
+            {'account': ferdie, 'whitelistMessage': ferdieWlMessage, 'race': 'Cyborg', 'career': 'Web3Monk'},
+            {'account': eve, 'whitelistMessage': eveWlMessage, 'race': 'XGene', 'career': 'RoboWarrior'}
+        ];
+        await usersPurchaseWhitelistOriginOfShells(api, userAccountsWhitelistOriginOfShellInfo);
+    });
+    after(() => {
+        api.disconnect();
+    });
+})

--- a/scripts/js/pw/util/fetch.js
+++ b/scripts/js/pw/util/fetch.js
@@ -1,0 +1,53 @@
+require('dotenv').config();
+
+// export async function getBalance(khalaApi, account)
+
+// export async function getOverlord(khalaApi)
+
+// export async function getZeroDay(khalaApi)
+
+// export async function getEra(khalaApi)
+
+// export async function getClaimSpiritStatus(khalaApi)
+
+// export async function getPurchaseRareOriginOfShellsStatus(khalaApi)
+
+// export async function getPurchasePrimeOriginOfShellsStatus(khalaApi)
+
+// export async function getPreorderOriginOfShellsStatus(khalaApi)
+
+// export async function getLastDayOfSaleStatus(khalaApi)
+
+// export async function getSpiritCollectionId(khalaApi)
+
+// export async function getOriginOfShellCollectionId(khalaApi)
+
+// export async function getIsOriginOfShellsInventorySet(khalaApi)
+
+// export async function getSpiritsMetadata(khalaApi)
+
+// export async function getOriginOfShellsMetadata(khalaApi, raceType)
+
+// export async function getNextNftId(khalaApi, collectionId)
+
+// export async function getPreorderIndex(khalaApi)
+
+// export async function getPreorder(khalaApi, preorderId)
+
+// export async function getOriginOfShellsInventory(khalaApi, rarityType)
+
+// export async function getFoodByOwners(khalaApi, account)
+
+// export async function getOriginOfShellFoodStats(khalaApi, eraId, collectionId, nftId)
+
+// export async function getOfficialHatchTime(khalaApi)
+
+// export async function getCanStartIncubationStatus(khalaApi)
+
+// export async function getHsOriginOfShellStartedIncubationStatus(khalaApi, collectionId, nftId)
+
+// export async function getShellcollectionId(khalaApi)
+
+// export async function getShellPartsCollectionId(khalaApi)
+
+// export async function getOriginOfShellsChosenParts(khalaApi, collectionId, nftId)

--- a/scripts/js/pw/util/fetch.js
+++ b/scripts/js/pw/util/fetch.js
@@ -1,4 +1,7 @@
-require('dotenv').config();
+
+async function getCollectionsCount(khalaApi) {
+    return (await khalaApi.query.rmrkCore.collectionIndex());
+}
 
 // export async function getBalance(khalaApi, account)
 
@@ -18,9 +21,17 @@ require('dotenv').config();
 
 // export async function getLastDayOfSaleStatus(khalaApi)
 
-// export async function getSpiritCollectionId(khalaApi)
+async function getSpiritCollectionId(khalaApi) {
+    console.log(`Querying Spirit Collection ID...`)
+    let collectionId = await khalaApi.query.pwNftSale.spiritCollectionId();
+    return collectionId;
+}
 
-// export async function getOriginOfShellCollectionId(khalaApi)
+async function getOriginOfShellCollectionId(khalaApi) {
+    console.log(`Querying Origin of Shell Collection ID...`)
+    let collectionId = await khalaApi.query.pwNftSale.originOfShellCollectionId();
+    return collectionId;
+}
 
 // export async function getIsOriginOfShellsInventorySet(khalaApi)
 
@@ -46,8 +57,24 @@ require('dotenv').config();
 
 // export async function getHsOriginOfShellStartedIncubationStatus(khalaApi, collectionId, nftId)
 
-// export async function getShellcollectionId(khalaApi)
+async function getShellCollectionId(khalaApi) {
+    console.log(`Querying Shell Collection ID...`)
+    let collectionId = await khalaApi.query.pwIncubation.shellCollectionId();
+    return collectionId;
+}
 
-// export async function getShellPartsCollectionId(khalaApi)
+async function getShellPartsCollectionId(khalaApi) {
+    console.log(`Querying Shell Parts Collection ID...`)
+    let collectionId = await khalaApi.query.pwIncubation.shellPartsCollectionId();
+    return collectionId;
+}
 
 // export async function getOriginOfShellsChosenParts(khalaApi, collectionId, nftId)
+
+module.exports = {
+    getCollectionsCount,
+    getSpiritCollectionId,
+    getOriginOfShellCollectionId,
+    getShellCollectionId,
+    getShellPartsCollectionId
+}

--- a/scripts/js/pw/util/fetch.js
+++ b/scripts/js/pw/util/fetch.js
@@ -1,6 +1,6 @@
 
 async function getCollectionsCount(khalaApi) {
-    return (await khalaApi.query.rmrkCore.collectionIndex());
+    return (await khalaApi.query.rmrkCore.collectionIndex()).toNumber();
 }
 
 // export async function getBalance(khalaApi, account)
@@ -22,13 +22,13 @@ async function getCollectionsCount(khalaApi) {
 // export async function getLastDayOfSaleStatus(khalaApi)
 
 async function getSpiritCollectionId(khalaApi) {
-    console.log(`Querying Spirit Collection ID...`)
+    console.log(`\tQuerying Spirit Collection ID...`)
     let collectionId = await khalaApi.query.pwNftSale.spiritCollectionId();
     return collectionId;
 }
 
 async function getOriginOfShellCollectionId(khalaApi) {
-    console.log(`Querying Origin of Shell Collection ID...`)
+    console.log(`\tQuerying Origin of Shell Collection ID...`)
     let collectionId = await khalaApi.query.pwNftSale.originOfShellCollectionId();
     return collectionId;
 }
@@ -58,13 +58,13 @@ async function getOriginOfShellCollectionId(khalaApi) {
 // export async function getHsOriginOfShellStartedIncubationStatus(khalaApi, collectionId, nftId)
 
 async function getShellCollectionId(khalaApi) {
-    console.log(`Querying Shell Collection ID...`)
+    console.log(`\tQuerying Shell Collection ID...`)
     let collectionId = await khalaApi.query.pwIncubation.shellCollectionId();
     return collectionId;
 }
 
 async function getShellPartsCollectionId(khalaApi) {
-    console.log(`Querying Shell Parts Collection ID...`)
+    console.log(`\tQuerying Shell Parts Collection ID...`)
     let collectionId = await khalaApi.query.pwIncubation.shellPartsCollectionId();
     return collectionId;
 }

--- a/scripts/js/pw/util/fetch.js
+++ b/scripts/js/pw/util/fetch.js
@@ -5,23 +5,37 @@ async function getCollectionsCount(khalaApi) {
 
 // export async function getBalance(khalaApi, account)
 
-// export async function getOverlord(khalaApi)
+async function getOverlord(khalaApi) {
+    return (await khalaApi.query.pwNftSale.overlord())
+}
 
-// export async function getZeroDay(khalaApi)
+async function getZeroDay(khalaApi) {
+    return (await khalaApi.query.pwNftSale.zeroDay())
+}
 
 async function getEra(khalaApi) {
     return (await khalaApi.query.pwNftSale.era()).toNumber();
 }
 
-// export async function getClaimSpiritStatus(khalaApi)
+async function getClaimSpiritStatus(khalaApi) {
+    return (await khalaApi.query.pwNftSale.canClaimSpirits());
+}
 
-// export async function getPurchaseRareOriginOfShellsStatus(khalaApi)
+async function getPurchaseRareOriginOfShellsStatus(khalaApi) {
+    return (await khalaApi.query.pwNftSale.canPurchaseRareOriginOfShells());
+}
 
-// export async function getPurchasePrimeOriginOfShellsStatus(khalaApi)
+async function getPurchasePrimeOriginOfShellsStatus(khalaApi) {
+    return (await khalaApi.query.pwNftSale.canPurchasePrimeOriginOfShells());
+}
 
-// export async function getPreorderOriginOfShellsStatus(khalaApi)
+async function getPreorderOriginOfShellsStatus(khalaApi) {
+    return (await khalaApi.query.pwNftSale.canPreorderOriginOfShells());
+}
 
-// export async function getLastDayOfSaleStatus(khalaApi)
+async function getLastDayOfSaleStatus(khalaApi) {
+    return (await khalaApi.query.pwNftSale.lastDayOfSale());
+}
 
 async function getSpiritCollectionId(khalaApi) {
     console.log(`\tQuerying Spirit Collection ID...`)
@@ -29,7 +43,7 @@ async function getSpiritCollectionId(khalaApi) {
     return collectionId;
 }
 
-async function getOriginOfShellCollectionId(khalaApi) {
+async function getOriginOfShellCollectionId(khalaApi) {Ï
     console.log(`\tQuerying Origin of Shell Collection ID...`)
     let collectionId = await khalaApi.query.pwNftSale.originOfShellCollectionId();
     return collectionId;
@@ -48,29 +62,63 @@ async function getOwnedOriginOfShells(khalaApi, account, collectionId) {
     return nfts;
 }
 
-// export async function getIsOriginOfShellsInventorySet(khalaApi)
+async function getIsOriginOfShellsInventorySet(khalaApi) {
+    return (await khalaApi.query.pwNftSale.isOriginOfShellsInventorySet());
+}
 
-// export async function getSpiritsMetadata(khalaApi)
+async function getSpiritsMetadata(khalaApi) {
+    return (await khalaApi.query.pwNftSale.spiritsMetadata());
+}
 
-// export async function getOriginOfShellsMetadata(khalaApi, raceType)
+async function getOriginOfShellsMetadata(khalaApi, raceType) {
+    return (await khalaApi.query.pwNftSale.originOfShellsMetadata(raceType));
+}
 
-// export async function getNextNftId(khalaApi, collectionId)
+async function getNextNftId(khalaApi, collectionId) {
+    return (await khalaApi.query.pwNftSale.nextNftId(collectionId)).toNumber();
+}
 
-// export async function getPreorderIndex(khalaApi)
+async function getNextResourceId(khalaApi, collectionId, nftId) {
+    return (await khalaApi.query.pwNftSale.nextResourceId(collectionId, nftId)).toNumber();
+}
 
-// export async function getPreorder(khalaApi, preorderId)
+async function getPreorderIndex(khalaApi) {
+    return (await khalaApi.query.pwNftSale.preorderIndex()).toNumber();
+}
 
-// export async function getOriginOfShellsInventory(khalaApi, rarityType)
+async function getPreorder(khalaApi, preorderId) {
+    return (await khalaApi.query.pwNftSale.preorders(preorderId));
+}
 
-// export async function getFoodByOwners(khalaApi, account)
+async function getOwnerHasPreorder(khalaApi, account) {
+    return (await khalaApi.query.pwNftSale.ownerHasPreorder(account));
+}
 
-// export async function getOriginOfShellFoodStats(khalaApi, eraId, collectionId, nftId)
+// Returns type NftSaleInfo for a RarityType and RaceType
+async function getOriginOfShellsInventory(khalaApi, rarityType, raceType) {
+    return (await khalaApi.query.pwNftSale.originOfShellsInventory(rarityType, raceType));
+}
 
-// export async function getOfficialHatchTime(khalaApi)
+// Returns the latest FoodInfo for an Account
+async function getFoodByOwners(khalaApi, account) {
+    return (await khalaApi.query.pwIncubation.foodByOwners(account));
+}
 
-// export async function getCanStartIncubationStatus(khalaApi)
+async function getOriginOfShellFoodStats(khalaApi, eraId, collectionId, nftId) {
+    return (await khalaApi.query.pwIncubation.originOfShellsFoodStats(eraId, (collectionId, nftId))).toNumber();
+}
 
-// export async function getHsOriginOfShellStartedIncubationStatus(khalaApi, collectionId, nftId)
+async function getOfficialHatchTime(khalaApi) {
+    return (await khalaApi.query.pwIncubation.officialHatchTime()).toNumber();
+}
+
+async function getCanStartIncubationStatus(khalaApi) {
+    return (await khalaApi.query.pwIncubation.canStartIncubation());
+}
+
+async function getHasOriginOfShellStartedIncubationStatus(khalaApi, collectionId, nftId) {
+    return (await khalaApi.query.pwIncubation.hasOriginOfShellStartedIncubation((collectionId, nftId)));
+}
 
 async function getShellCollectionId(khalaApi) {
     console.log(`\tQuerying Shell Collection ID...`)
@@ -84,7 +132,9 @@ async function getShellPartsCollectionId(khalaApi) {
     return collectionId;
 }
 
-// export async function getOriginOfShellsChosenParts(khalaApi, collectionId, nftId)
+async function getOriginOfShellsChosenParts(khalaApi, collectionId, nftId) {
+    return (await khalaApi.query.pwIncubation.originOfShellsChosenParts((collectionId, nftId)));
+}
 
 module.exports = {
     getCollectionsCount,
@@ -93,5 +143,27 @@ module.exports = {
     getShellCollectionId,
     getShellPartsCollectionId,
     getEra,
-    getOwnedOriginOfShells
+    getOwnedOriginOfShells,
+    getOverlord,
+    getZeroDay,
+    getClaimSpiritStatus,
+    getPurchaseRareOriginOfShellsStatus,
+    getPurchasePrimeOriginOfShellsStatus,
+    getPreorderOriginOfShellsStatus,
+    getLastDayOfSaleStatus,
+    getIsOriginOfShellsInventorySet,
+    getSpiritsMetadata,
+    getOriginOfShellsMetadata,
+    getNextNftId,
+    getNextResourceId,
+    getPreorderIndex,
+    getPreorder,
+    getOwnerHasPreorder,
+    getOriginOfShellsInventory,
+    getFoodByOwners,
+    getOriginOfShellFoodStats,
+    getOfficialHatchTime,
+    getCanStartIncubationStatus,
+    getHasOriginOfShellStartedIncubationStatus,
+    getOriginOfShellsChosenParts
 }

--- a/scripts/js/pw/util/fetch.js
+++ b/scripts/js/pw/util/fetch.js
@@ -9,7 +9,9 @@ async function getCollectionsCount(khalaApi) {
 
 // export async function getZeroDay(khalaApi)
 
-// export async function getEra(khalaApi)
+async function getEra(khalaApi) {
+    return (await khalaApi.query.pwNftSale.era()).toNumber();
+}
 
 // export async function getClaimSpiritStatus(khalaApi)
 
@@ -31,6 +33,19 @@ async function getOriginOfShellCollectionId(khalaApi) {
     console.log(`\tQuerying Origin of Shell Collection ID...`)
     let collectionId = await khalaApi.query.pwNftSale.originOfShellCollectionId();
     return collectionId;
+}
+
+async function getOwnedOriginOfShells(khalaApi, account, collectionId) {
+    let nfts = [];
+    const originOfShells = await khalaApi.query.uniques.account.entries(account.address, collectionId);
+    originOfShells
+        .map(([key, _value]) =>
+            [key.args[0].toString(), key.args[1].toNumber(), key.args[2].toNumber()]
+        ).forEach(([acct, colId, nftId]) => {
+        nfts.push(nftId);
+        console.log(`\tAdding [${acct}, ${colId}, ${nftId}]`);
+    });
+    return nfts;
 }
 
 // export async function getIsOriginOfShellsInventorySet(khalaApi)
@@ -76,5 +91,7 @@ module.exports = {
     getSpiritCollectionId,
     getOriginOfShellCollectionId,
     getShellCollectionId,
-    getShellPartsCollectionId
+    getShellPartsCollectionId,
+    getEra,
+    getOwnedOriginOfShells
 }

--- a/scripts/js/pw/util/fetch.js
+++ b/scripts/js/pw/util/fetch.js
@@ -136,6 +136,23 @@ async function getOriginOfShellsChosenParts(khalaApi, collectionId, nftId) {
     return (await khalaApi.query.pwIncubation.originOfShellsChosenParts((collectionId, nftId)));
 }
 
+async function getOwnedNftsInCollection(khalaApi, account, collectionId) {
+    let nfts = [];
+    const originOfShells = await khalaApi.query.uniques.account.entries(account.address, collectionId);
+    originOfShells
+        .map(([key, _value]) =>
+            [key.args[0].toString(), key.args[1].toNumber(), key.args[2].toNumber()]
+        ).forEach(([acct, colId, nftId]) => {
+        nfts.push(nftId);
+        console.log(`\tDetected owner:[${acct}] (collection_id, nft_id):[${colId}, ${nftId}]`);
+    });
+    return nfts;
+}
+
+async function getNftInfo(khalaApi, collectionId, nftId) {
+    return (await khalaApi.query.rmrkCore.nfts(collectionId, nftId));
+}
+
 module.exports = {
     getCollectionsCount,
     getSpiritCollectionId,
@@ -165,5 +182,7 @@ module.exports = {
     getOfficialHatchTime,
     getCanStartIncubationStatus,
     getHasOriginOfShellStartedIncubationStatus,
-    getOriginOfShellsChosenParts
+    getOriginOfShellsChosenParts,
+    getOwnedNftsInCollection,
+    getNftInfo
 }

--- a/scripts/js/pw/util/helpers.js
+++ b/scripts/js/pw/util/helpers.js
@@ -89,6 +89,12 @@ function waitExtrinsicFinished(khalaApi, extrinsic, account) {
     });
 }
 
+// Create Whitelist for account and sign with Overlord
+async function createWhitelistMessage(khalaApi, type, overlord, account) {
+    const whitelistMessage = khalaApi.createType(type, {'account': account.address, 'purpose': 'BuyPrimeOriginOfShells'});
+    return overlord.sign(whitelistMessage.toU8a());
+}
+
 module.exports = {
     getNonce,
     checkUntil,
@@ -97,5 +103,6 @@ module.exports = {
     getCollectionType,
     waitTxAccepted,
     waitExtrinsicFinished,
-    token
+    token,
+    createWhitelistMessage
 }

--- a/scripts/js/pw/util/helpers.js
+++ b/scripts/js/pw/util/helpers.js
@@ -95,6 +95,23 @@ async function createWhitelistMessage(khalaApi, type, overlord, account) {
     return overlord.sign(whitelistMessage.toU8a());
 }
 
+async function getTopNFed(khalaApi, era, sliceNSize) {
+    const originOfShellFoodStats = await khalaApi.query.pwIncubation.originOfShellFoodStats.entries(era);
+    const sortedOriginOfShellStats = originOfShellFoodStats
+        .map(([key, value]) => {
+                const eraId = key.args[0].toNumber()
+                const collectionIdNftId = key.args[1].toHuman()
+                const numTimesFed = value.toNumber()
+                return {
+                    eraId: eraId,
+                    collectionIdNftId: collectionIdNftId,
+                    numTimesFed: numTimesFed
+                }
+            }
+        ).sort((a, b) => b.numTimesFed - a.numTimesFed);
+    return sortedOriginOfShellStats.slice(0, sliceNSize);
+}
+
 module.exports = {
     getNonce,
     checkUntil,
@@ -104,5 +121,6 @@ module.exports = {
     waitTxAccepted,
     waitExtrinsicFinished,
     token,
-    createWhitelistMessage
+    createWhitelistMessage,
+    getTopNFed
 }

--- a/scripts/js/pw/util/helpers.js
+++ b/scripts/js/pw/util/helpers.js
@@ -1,6 +1,6 @@
 const BN = require('bn.js');
 const sleep = require('p-sleep');
-const { getSpiritCollectionId, getOriginOfShellCollectionId, getShellCollectionId, getShellPartsCollectionId } = require('./fetch');
+const { getSpiritCollectionId, getOriginOfShellCollectionId, getShellCollectionId, getShellPartsCollectionId, getNftInfo } = require('./fetch');
 const bnUnit = new BN(1e12);
 function token(n) {
     return new BN(n).mul(bnUnit);
@@ -112,6 +112,19 @@ async function getTopNFed(khalaApi, era, sliceNSize) {
     return sortedOriginOfShellStats.slice(0, sliceNSize);
 }
 
+async function getNonTransferableNft(khalaApi, collectionId, nfts) {
+    for (const nft in nfts) {
+        let nftInfo = await getNftInfo(khalaApi, collectionId, nft);
+        if (nftInfo.isSome) {
+            let nftInfoUnwrap = nftInfo.unwrap();
+            if (nftInfoUnwrap.transferable) {
+                return nft;
+            }
+        }
+    }
+    return -1;
+}
+
 module.exports = {
     getNonce,
     checkUntil,
@@ -122,5 +135,6 @@ module.exports = {
     waitExtrinsicFinished,
     token,
     createWhitelistMessage,
-    getTopNFed
+    getTopNFed,
+    getNonTransferableNft
 }

--- a/scripts/js/pw/util/helpers.js
+++ b/scripts/js/pw/util/helpers.js
@@ -1,0 +1,80 @@
+const BN = require('bn.js');
+const sleep = require('p-sleep');
+
+const bnUnit = new BN(1e12);
+function token(n) {
+    return new BN(n).mul(bnUnit);
+}
+
+async function checkUntil(async_fn, timeout) {
+    const t0 = new Date().getTime();
+    while (true) {
+        if (await async_fn()) {
+            return true;
+        }
+        const t = new Date().getTime();
+        if (t - t0 >= timeout) {
+            return false;
+        }
+        await sleep(100);
+    }
+}
+
+async function getNonce(khalaApi, address) {
+    const info = await khalaApi.query.system.account(address);
+    return info.nonce.toNumber();
+}
+
+async function waitTxAccepted(khalaApi, account, nonce) {
+    await checkUntil(async () => {
+        return await getNonce(khalaApi, account) === nonce + 1;
+    });
+}
+
+function waitExtrinsicFinished(khalaApi, extrinsic, account) {
+    return new Promise(async (resolve, reject) => {
+        const unsub = await extrinsic.signAndSend(account, (result) => {
+            if (result.status.isInBlock) {
+                console.log(`Transaction included at blockHash ${result.status.asInBlock}`);
+            } else if (result.status.isFinalized) {
+                console.log(`Transaction finalized at blockHash ${result.status.asFinalized}`);
+            }
+
+            if (result.status.isInBlock || result.status.isFinalized) {
+                const failures = result.events.filter(({event}) => {
+                    return khalaApi.events.system?.ExtrinsicFailed?.is(event)
+                })
+                const errors = failures.map(
+                    ({
+                         event: {
+                             data: [error],
+                         },
+                     }) => {
+                        if (error?.isModule?.valueOf()) {
+                            // https://polkadot.js.org/docs/api/cookbook/tx#how-do-i-get-the-decoded-enum-for-an-extrinsicfailed-event
+                            const decoded = khalaApi.registry.findMetaError(error.asModule)
+                            const {docs, method, section} = decoded
+                            return new Error(`Extrinsic Failed: ${section}.${method}: ${docs.join(' ')}`)
+                        } else {
+                            return new Error(error?.toString() ?? String.toString.call(error))
+                        }
+                    }
+                )
+                if (errors.length > 0) {
+                    reject(errors[0])
+                } else {
+                    resolve()
+                }
+                unsub();
+            }
+        });
+    })
+}
+
+module.exports = {
+    getNonce,
+    checkUntil,
+    waitTxAccepted,
+    waitExtrinsicFinished,
+    token
+}

--- a/scripts/js/pw/util/helpers.js
+++ b/scripts/js/pw/util/helpers.js
@@ -1,9 +1,26 @@
 const BN = require('bn.js');
 const sleep = require('p-sleep');
+const { getSpiritCollectionId, getOriginOfShellCollectionId, getShellCollectionId, getShellPartsCollectionId } = require('./fetch');
 
 const bnUnit = new BN(1e12);
 function token(n) {
     return new BN(n).mul(bnUnit);
+}
+
+async function getCollectionType(khalaApi, collectionType) {
+    let collectionId = -1;
+    if (collectionType === "spirit") {
+        collectionId = await getSpiritCollectionId(khalaApi);
+    } else if (collectionType === "originOfShell") {
+        collectionId =await getOriginOfShellCollectionId(khalaApi);
+    } else if (collectionType === "shell") {
+        collectionId = await getShellCollectionId(khalaApi);
+    } else if (collectionType === "shellParts") {
+        collectionId = await getShellPartsCollectionId(khalaApi);
+    } else {
+        return collectionId;
+    }
+    return collectionId;
 }
 
 async function checkUntil(async_fn, timeout) {
@@ -74,6 +91,7 @@ function waitExtrinsicFinished(khalaApi, extrinsic, account) {
 module.exports = {
     getNonce,
     checkUntil,
+    getCollectionType,
     waitTxAccepted,
     waitExtrinsicFinished,
     token

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -208,6 +208,64 @@ async function usersPurchaseRareOriginOfShells(khalaApi, recipientsInfo) {
     }
 }
 
+// Users Purchase Whitelist Origin of Shells
+async function usersPurchaseWhitelistOriginOfShells(khalaApi, recipientsInfo) {
+    for (const recipient of recipientsInfo) {
+        const account = recipient.account;
+        const whitelistMessage = recipient.whitelistMessage;
+        const race = recipient.race;
+        const career = recipient.career;
+        let result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.pwNftSale.buyPrimeOriginOfShell(whitelistMessage, race, career), account);
+        expect(
+            result,
+            `Error: Purchasing Prime Origin of Shell for owner: ${account.address}, whitelistMessage: ${whitelistMessage}, race: ${race}, career: ${career}`
+        ).to.be.true
+    }
+}
+
+// Update RarityType Count for Prime Origin Of Shells
+async function updateRarityTypeCounts(khalaApi, overlord, rarityType, forSaleCount, giveawayCount) {
+    let tx = khalaApi.tx.pwNftSale.updateRarityTypeCounts(rarityType, forSaleCount, giveawayCount);
+    let result = await waitExtrinsicFinished(khalaApi, tx, overlord);
+    expect(
+        result,
+        `Error: Could not update RarityType ${rarityType} inventory counts`
+    ).to.be.true
+}
+
+
+// Users Preorder Origin of Shells
+async function userPreorderOriginOfShell(khalaApi, preordersInfo) {
+    for (const preorder of preordersInfo) {
+        const account = preorder.account;
+        const race = preorder.race;
+        const career = preorder.career;
+        const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.pwNftSale.preorderOriginOfShell(race, career), account);
+        expect(
+            result,
+            `Error: Starting Preorder Origin of Shell account: ${account}, race: ${race}, career: ${career}...`
+        ).to.be.true;
+    }
+}
+
+// Mint chosen preorders
+async function mintChosenPreorders(khalaApi, overlord, chosenPreorders) {
+    let result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.pwNftSale.mintChosenPreorders(chosenPreorders), overlord);
+    expect(
+        result,
+        `Error: Mint Chosen Preorders ${chosenPreorders} Failed`
+    ).to.be.true;
+}
+
+// Refund not chosen preorders
+async function refundNotChosenPreorders(khalaApi, overlord, notChosenPreorders) {
+    let result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.pwNftSale.refundNotChosenPreorders(notChosenPreorders), overlord);
+    expect(
+        result,
+        `Error: Refunding Not Chosen Preorders ${notChosenPreorders} Failed`
+    ).to.be.true;
+}
+
 module.exports = {
     pwCreateCollection,
     setStatusType,
@@ -219,5 +277,10 @@ module.exports = {
     addSpiritMetadata,
     usersClaimSpirits,
     addOriginOfShellsMetadata,
-    usersPurchaseRareOriginOfShells
+    usersPurchaseRareOriginOfShells,
+    usersPurchaseWhitelistOriginOfShells,
+    updateRarityTypeCounts,
+    userPreorderOriginOfShell,
+    mintChosenPreorders,
+    refundNotChosenPreorders
 }

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -1,0 +1,91 @@
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const { getCollectionsCount } = require('./fetch');
+const { token, waitExtrinsicFinished, getNonce, getCollectionType } = require('./helpers');
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+async function pwCreateCollection(
+    khalaApi,
+    overlord,
+    metadata,
+    maxOptional,
+    symbol,
+    collectionType // spirit, originOfShell, shell, shellParts
+) {
+    const oldCollectionCount = await getCollectionsCount(khalaApi);
+    let expectCollectionType = await getCollectionType(khalaApi, collectionType);
+    if (expectCollectionType === -1) {
+        console.log(`Error: invalid collectionType[${collectionType}]`);
+        expect(expectCollectionType).to.be.not.equal(-1, `Error: invalid collectionType[${collectionType}]`);
+    } else if (expectCollectionType.isSome) {
+        expect(
+            expectCollectionType.isSome,
+    `Error: collectionType[${collectionType}] is already set to collectionId[${expectCollectionType.unwrap().toNumber()}]`
+        ).to.be.false;
+    }
+    const tx = khalaApi.tx.pwNftSale.pwCreateCollection(metadata, maxOptional, symbol);
+    // TODO: Handle Events if we want to expand functionality later
+    await waitExtrinsicFinished(khalaApi, tx, overlord);
+    const newCollectionCount = await getCollectionsCount(khalaApi);
+    expect(newCollectionCount.toNumber()).to.be.equal(
+        oldCollectionCount.toNumber() + 1,
+        "Error: NFT collection count should increase"
+    );
+    await pwSetCollection(khalaApi, overlord, oldCollectionCount.toNumber(), collectionType);
+}
+
+async function pwSetCollection(
+    khalaApi,
+    overlord,
+    collectionId,
+    collectionType
+) {
+    let tx = null;
+    if (collectionType === "spirit") {
+        tx = khalaApi.tx.pwNftSale.setSpiritCollectionId(collectionId);
+    } else if (collectionType === "originOfShell") {
+        tx =  khalaApi.tx.pwNftSale.setOriginOfShellCollectionId(collectionId);
+    } else if (collectionType === "shell") {
+        tx = khalaApi.tx.pwIncubation.setShellCollectionId(collectionId);
+    } else if (collectionType === "shellParts") {
+        tx = khalaApi.tx.pwIncubation.setShellPartsCollectionId(collectionId);
+    } else {
+        return new Error(`Error: Incorrect collectionType[${collectionType}]`);
+    }
+    await waitExtrinsicFinished(khalaApi, tx, overlord);
+    let expectCollectionType = await getCollectionType(khalaApi, collectionType);
+    expect(
+        expectCollectionType.isSome,
+        `Error: collectionType[${collectionType}] not set for collectionId[${collectionId}]`
+    ).to.be.true;
+    expect(expectCollectionType.unwrap().toNumber()).to.be.equal(
+        collectionId,
+        `Error: collectionId[${collectionId} does not match expected collectionId[${expectCollectionType.unwrap}]`
+    );
+}
+
+// Set StatusType for
+async function setStatusType(khalaApi, overlord, statusType, status) {
+    let nonceOverlord = await getNonce(khalaApi, overlord.address);
+    return new Promise(async (resolve) => {
+        console.log(`Setting ${statusType} to ${status}...`);
+        const unsub = await khalaApi.tx.pwNftSale.setStatusType(status, statusType
+        ).signAndSend(overlord, {nonce: nonceOverlord++}, ({ events, status }, result) => {
+            if (status.isInBlock) {
+                console.log(`Transaction included at blockHash ${status.asInBlock}`);
+            } else if (status.isFinalized) {
+                console.log(`Transaction finalized at blockHash ${status.asFinalized}`);
+                unsub();
+                resolve();
+            }
+        });
+        await waitTxAccepted(khalaApi, overlord.address, nonceOverlord - 1);
+    });
+}
+
+module.exports = {
+    pwCreateCollection,
+    setStatusType
+}

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -345,45 +345,89 @@ async function hatchOriginOfShell(khalaApi, overlord, originOfShellsOwners) {
 // List NFT for sale. When a NFT is listed, the NFT sets the Lock StorageValue for the NFT to true. This will prevent the
 // NFT from being transferred or modified during the time the Lock is enabled.
 async function listNft(khalaApi, owner, collectionId, nftId, amount, maybeExpires) {
-    console.log(`\tListing Shell NFT ID [${collectionId}, ${nftId}] for sale...`);
-    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.list(collectionId, nftId, amount, maybeExpires), owner);
+    console.log(`\tListing NFT ID [${collectionId}, ${nftId}] for sale...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.list(collectionId, nftId, amount, maybeExpires), owner);
+    expect(
+        result,
+        `Error: could not list NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
 }
 
 // Buy NFT for sale. The buyer can set an Option<maybeAmount> to ensure that the buyer is buying at the expected price
 // of the listed NFT. Once the purchase passes permissions checks, the NFT is unlocked, money is transferred to the old
 // owner, the NFT is sent to the buyer & an event is emitted named TokenSold {owner, buyer, collection_id, nft_id, price}
 async function buyNft(khalaApi, buyer, collectionId, nftId, maybeAmount) {
-    console.log(`\tBuying Shell NFT ID [${collectionId}, ${nftId}]...`);
-    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.buy(collectionId, nftId, maybeAmount), buyer);
+    console.log(`\tBuying NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.buy(collectionId, nftId, maybeAmount), buyer);
+    expect(
+        result,
+        `Error: could not buy NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
 }
 
 // Unlist NFT for sale. The owner can unlist the NFT listed in the market. This will set the Lock to false & remove the
 // listed NFT from ListedNfts storage.
 async function unlistNft(khalaApi, owner, collectionId, nftId) {
-    console.log(`\tUnlisting Shell NFT ID [${collectionId}, ${nftId}]...`);
-    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.unlist(collectionId, nftId), owner);
+    console.log(`\tUnlisting NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.unlist(collectionId, nftId), owner);
+    expect(
+        result,
+        `Error: could not unlist NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
 }
 
 // Make Offer for NFT. The Offerer will make an offer on a NFT at a set amount with an optional BlockNumber defined for
 // when the offer expires. When the owner sees this offer in Offers storage then the owner can accept the offer.
 async function makeOfferOnNft(khalaApi, offerer, collectionId, nftId, amount, maybeExpires) {
-    console.log(`\tMake offer on Shell NFT ID [${collectionId}, ${nftId}]...`);
-    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.makeOffer(collectionId, nftId, amount, maybeExpires), offerer);
+    console.log(`\tMake offer on NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.makeOffer(collectionId, nftId, amount, maybeExpires), offerer);
+    expect(
+        result,
+        `Error: could not make offer on NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
 }
 
 // Accept Offer for NFT. The owner can accept an active offer in storage for a NFT. This will remove the offer from storage,
 // unreserve the offer from the offerer then transfer the funs to the current owner, then the NFT is sent to the offerer.
 // This triggers an event OfferAccepted {owner, buyer, collection_id, nft_id}
 async function acceptOfferOnNft(khalaApi, owner, collectionId, nftId, offerer) {
-    console.log(`\tAccept offer on Shell NFT ID [${collectionId}, ${nftId}]...`);
-    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.acceptOffer(collectionId, nftId, offerer), owner);
+    console.log(`\tAccept offer on NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.acceptOffer(collectionId, nftId, offerer), owner);
+    expect(
+        result,
+        `Error: could not accept offer on NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
 }
 
 // Withdraw Offer for NFT. The offerer can withdraw an offer on a NFT which will remove the offer from the Offers in
 // storage and the offer will no longer be able to be accepted.
 async function withdrawOfferOnNft(khalaApi, offerer, collectionId, nftId) {
-    console.log(`\tWithdraw offer on Shell NFT ID [${collectionId}, ${nftId}]...`);
-    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.withdrawOffer(collectionId, nftId), offerer);
+    console.log(`\tWithdraw offer on NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.withdrawOffer(collectionId, nftId), offerer);
+    expect(
+        result,
+        `Error: could not withdraw offer on NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
+}
+
+// Send NFT to new account Owner
+async function sendNftToOwner(khalaApi, owner, collectionId, nftId, newOwner) {
+    console.log(`\tSending NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkCore.send(collectionId, nftId, newOwner.address), owner);
+    expect(
+        result,
+        `Error: could not send NFT ID [${collectionId}, ${nftId}]`
+    ).to.be.true;
+}
+
+// Fail to send
+async function failToSendNonTransferableNft(khalaApi, owner, collectionId, nftId, newOwner) {
+    console.log(`\tExpected to fail sending NFT ID [${collectionId}, ${nftId}]...`);
+    const result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkCore.send(collectionId, nftId, newOwner.address), owner);
+    expect(
+        result,
+        `Error: Expected failure, but NFT ID [${collectionId}, ${nftId}] successfully sent`
+    ).to.be.false;
 }
 
 module.exports = {
@@ -413,5 +457,7 @@ module.exports = {
     unlistNft,
     makeOfferOnNft,
     acceptOfferOnNft,
-    withdrawOfferOnNft
+    withdrawOfferOnNft,
+    sendNftToOwner,
+    failToSendNonTransferableNft
 }

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -1,10 +1,57 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { getCollectionsCount } = require('./fetch');
-const { token, waitExtrinsicFinished, getNonce, getCollectionType } = require('./helpers');
+const { token, extractTxResult, waitExtrinsicFinished, getNonce, getCollectionType, waitTxAccepted } = require('./helpers');
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
+
+// Transfer balance to an account
+async function transferPha(khalaApi, sender, recipients, amount) {
+    let senderNonce = await getNonce(khalaApi, sender.address);
+    return new Promise(async (resolve) => {
+        console.log(`\tStarting transfers...`);
+        for (const recipient of recipients) {
+            const index = recipients.indexOf(recipient);
+            console.log(`\t[${index}]: Transferring ${amount.toString()} PHA from ${sender.address} to ${recipient.address}`);
+            const unsub = await khalaApi.tx.balances.transfer(recipient.address, amount).signAndSend(sender, {nonce: senderNonce++}, (result) => {
+                if (result.status.isInBlock) {
+                    console.log(`\tTransaction included at blockHash ${result.status.asInBlock}`);
+                } else if (result.status.isFinalized) {
+                    console.log(`\tTransaction finalized at blockHash ${result.status.asFinalized}`);
+                    unsub();
+                    resolve();
+                }
+            });
+            console.log(`\t[${index}]: Transferring...DONE`);
+        }
+        await waitTxAccepted(khalaApi, sender.address, senderNonce - 1);
+    });
+}
+
+// Set Overlord Account with Sudo account
+async function setOverlordAccount(khalaApi, sender, newOverlord) {
+    const tx = khalaApi.tx.sudo.sudo(
+        khalaApi.tx.pwNftSale.setOverlord(newOverlord.address)
+    );
+    const result = await waitExtrinsicFinished(khalaApi, tx, sender);
+    //const result = extractTxResult(events);
+    expect(
+        result,
+        `Error: could not set new overlord[${newOverlord.address}]`
+    ).to.be.true;
+}
+
+// Initialize PhalaWorld Clock
+async function initializePhalaWorldClock(khalaApi, overlord) {
+    const tx = khalaApi.tx.pwNftSale.initializeWorldClock();
+    const result = await waitExtrinsicFinished(khalaApi, tx, overlord);
+    //const result = extractTxResult(events);
+    expect(
+        result,
+        `Error: could not set PhalaWorld Clock`
+    ).to.be.true;
+}
 
 async function pwCreateCollection(
     khalaApi,
@@ -16,24 +63,39 @@ async function pwCreateCollection(
 ) {
     const oldCollectionCount = await getCollectionsCount(khalaApi);
     let expectCollectionType = await getCollectionType(khalaApi, collectionType);
-    if (expectCollectionType === -1) {
-        console.log(`Error: invalid collectionType[${collectionType}]`);
-        expect(expectCollectionType).to.be.not.equal(-1, `Error: invalid collectionType[${collectionType}]`);
-    } else if (expectCollectionType.isSome) {
-        expect(
-            expectCollectionType.isSome,
-    `Error: collectionType[${collectionType}] is already set to collectionId[${expectCollectionType.unwrap().toNumber()}]`
-        ).to.be.false;
-    }
-    const tx = khalaApi.tx.pwNftSale.pwCreateCollection(metadata, maxOptional, symbol);
+    expect(
+        expectCollectionType
+    ).to.be.not.equal(
+    -1,
+    `Error: invalid collectionType[${collectionType}]`
+    );
+    expect(
+        expectCollectionType.isSome,
+`Error: collectionType[${collectionType}] is already set`
+    ).to.be.false;
+    const tx = khalaApi.tx.pwNftSale.pwCreateCollection(
+        metadata,
+        maxOptional,
+        symbol
+    );
     // TODO: Handle Events if we want to expand functionality later
-    await waitExtrinsicFinished(khalaApi, tx, overlord);
+    const result = await waitExtrinsicFinished(khalaApi, tx, overlord);
+    //const result = extractTxResult(events);
+    expect(
+        result,
+        `Error: create collectionId[${oldCollectionCount}]`
+    ).to.be.true;
     const newCollectionCount = await getCollectionsCount(khalaApi);
-    expect(newCollectionCount.toNumber()).to.be.equal(
-        oldCollectionCount.toNumber() + 1,
+    expect(newCollectionCount).to.be.equal(
+        oldCollectionCount + 1,
         "Error: NFT collection count should increase"
     );
-    await pwSetCollection(khalaApi, overlord, oldCollectionCount.toNumber(), collectionType);
+    await pwSetCollection(
+        khalaApi,
+        overlord,
+        oldCollectionCount,
+        collectionType
+    );
 }
 
 async function pwSetCollection(
@@ -52,9 +114,19 @@ async function pwSetCollection(
     } else if (collectionType === "shellParts") {
         tx = khalaApi.tx.pwIncubation.setShellPartsCollectionId(collectionId);
     } else {
-        return new Error(`Error: Incorrect collectionType[${collectionType}]`);
+        expect(
+            tx
+        ).to.be.not.equal(
+            null,
+            `Error: Incorrect collectionType[${collectionType}]`
+        );
     }
-    await waitExtrinsicFinished(khalaApi, tx, overlord);
+    let result = await waitExtrinsicFinished(khalaApi, tx, overlord);
+    //let result = extractTxResult(events);
+    expect(
+        result,
+        `ErrorError: collectionType[${collectionType}] not set for collectionId[${collectionId}]`
+    ).to.be.true;
     let expectCollectionType = await getCollectionType(khalaApi, collectionType);
     expect(
         expectCollectionType.isSome,
@@ -66,6 +138,17 @@ async function pwSetCollection(
     );
 }
 
+// Set PhalaWorld Rarity Inventory Count
+async function initializeRarityTypeCounts(khalaApi, overlord) {
+    const tx = khalaApi.tx.pwNftSale.initRarityTypeCounts();
+    const result = await waitExtrinsicFinished(khalaApi, tx, overlord);
+    //const result = extractTxResult(events);
+    expect(
+        result,
+        `Error: could not set PhalaWorld RarityType Inventory Count`
+    ).to.be.true;
+}
+
 // Set StatusType for
 async function setStatusType(khalaApi, overlord, statusType, status) {
     let nonceOverlord = await getNonce(khalaApi, overlord.address);
@@ -74,9 +157,9 @@ async function setStatusType(khalaApi, overlord, statusType, status) {
         const unsub = await khalaApi.tx.pwNftSale.setStatusType(status, statusType
         ).signAndSend(overlord, {nonce: nonceOverlord++}, ({ events, status }, result) => {
             if (status.isInBlock) {
-                console.log(`Transaction included at blockHash ${status.asInBlock}`);
+                console.log(`\tTransaction included at blockHash ${status.asInBlock}`);
             } else if (status.isFinalized) {
-                console.log(`Transaction finalized at blockHash ${status.asFinalized}`);
+                console.log(`\tTransaction finalized at blockHash ${status.asFinalized}`);
                 unsub();
                 resolve();
             }
@@ -87,5 +170,9 @@ async function setStatusType(khalaApi, overlord, statusType, status) {
 
 module.exports = {
     pwCreateCollection,
-    setStatusType
+    setStatusType,
+    transferPha,
+    setOverlordAccount,
+    initializePhalaWorldClock,
+    initializeRarityTypeCounts
 }

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -327,7 +327,7 @@ async function hatchOriginOfShell(khalaApi, overlord, originOfShellsOwners) {
     const defaultMetadata = "";
     let nonceOverlord = await getNonce(khalaApi, overlord.address);
     for (const accountId of originOfShellsOwners) {
-        const originOfShellCollectionId = await getOriginOfShellCollectionId();
+        const originOfShellCollectionId = await getOriginOfShellCollectionId(khalaApi);
         expect(
             originOfShellCollectionId.isSome,
             `Error: Origin of Shell Collection ID Not Set`

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -182,6 +182,32 @@ async function usersClaimSpirits(khalaApi, recipients) {
     }
 }
 
+// Add Origin of Shells Metadata
+async function addOriginOfShellsMetadata(khalaApi, overlord, originOfShellsMetadataArr) {
+    const tx = khalaApi.tx.pwNftSale.setOriginOfShellsMetadata(originOfShellsMetadataArr);
+    const result = await waitExtrinsicFinished(khalaApi, tx, overlord);
+    expect(
+        result,
+        `Error: could not set Origin of Shells metadata[${originOfShellsMetadataArr}]`
+    ).to.be.true;
+}
+
+// Simulate Rare Origin of Shells Purchases
+async function usersPurchaseRareOriginOfShells(khalaApi, recipientsInfo) {
+    for (const recipient of recipientsInfo) {
+        const account = recipient.account;
+        const rarity = recipient.rarity;
+        const race = recipient.race;
+        const career = recipient.career;
+        const amount = recipient.amount;
+        let result = await waitExtrinsicFinished(khalaApi, khalaApi.tx.pwNftSale.buyRareOriginOfShell(rarity, race, career), account);
+        expect(
+            result,
+            `Error: Failed Purchasing Rare Origin of Shell for owner: ${account.address}, rarity: ${rarity}, race: ${race}, career: ${career}, amount: ${amount}`
+        ).to.be.true;
+    }
+}
+
 module.exports = {
     pwCreateCollection,
     setStatusType,
@@ -191,5 +217,7 @@ module.exports = {
     initializeRarityTypeCounts,
     setStatusType,
     addSpiritMetadata,
-    usersClaimSpirits
+    usersClaimSpirits,
+    addOriginOfShellsMetadata,
+    usersPurchaseRareOriginOfShells
 }

--- a/scripts/js/pw/util/tx.js
+++ b/scripts/js/pw/util/tx.js
@@ -342,6 +342,50 @@ async function hatchOriginOfShell(khalaApi, overlord, originOfShellsOwners) {
     }
 }
 
+// List NFT for sale. When a NFT is listed, the NFT sets the Lock StorageValue for the NFT to true. This will prevent the
+// NFT from being transferred or modified during the time the Lock is enabled.
+async function listNft(khalaApi, owner, collectionId, nftId, amount, maybeExpires) {
+    console.log(`\tListing Shell NFT ID [${collectionId}, ${nftId}] for sale...`);
+    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.list(collectionId, nftId, amount, maybeExpires), owner);
+}
+
+// Buy NFT for sale. The buyer can set an Option<maybeAmount> to ensure that the buyer is buying at the expected price
+// of the listed NFT. Once the purchase passes permissions checks, the NFT is unlocked, money is transferred to the old
+// owner, the NFT is sent to the buyer & an event is emitted named TokenSold {owner, buyer, collection_id, nft_id, price}
+async function buyNft(khalaApi, buyer, collectionId, nftId, maybeAmount) {
+    console.log(`\tBuying Shell NFT ID [${collectionId}, ${nftId}]...`);
+    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.buy(collectionId, nftId, maybeAmount), buyer);
+}
+
+// Unlist NFT for sale. The owner can unlist the NFT listed in the market. This will set the Lock to false & remove the
+// listed NFT from ListedNfts storage.
+async function unlistNft(khalaApi, owner, collectionId, nftId) {
+    console.log(`\tUnlisting Shell NFT ID [${collectionId}, ${nftId}]...`);
+    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.unlist(collectionId, nftId), owner);
+}
+
+// Make Offer for NFT. The Offerer will make an offer on a NFT at a set amount with an optional BlockNumber defined for
+// when the offer expires. When the owner sees this offer in Offers storage then the owner can accept the offer.
+async function makeOfferOnNft(khalaApi, offerer, collectionId, nftId, amount, maybeExpires) {
+    console.log(`\tMake offer on Shell NFT ID [${collectionId}, ${nftId}]...`);
+    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.makeOffer(collectionId, nftId, amount, maybeExpires), offerer);
+}
+
+// Accept Offer for NFT. The owner can accept an active offer in storage for a NFT. This will remove the offer from storage,
+// unreserve the offer from the offerer then transfer the funs to the current owner, then the NFT is sent to the offerer.
+// This triggers an event OfferAccepted {owner, buyer, collection_id, nft_id}
+async function acceptOfferOnNft(khalaApi, owner, collectionId, nftId, offerer) {
+    console.log(`\tAccept offer on Shell NFT ID [${collectionId}, ${nftId}]...`);
+    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.acceptOffer(collectionId, nftId, offerer), owner);
+}
+
+// Withdraw Offer for NFT. The offerer can withdraw an offer on a NFT which will remove the offer from the Offers in
+// storage and the offer will no longer be able to be accepted.
+async function withdrawOfferOnNft(khalaApi, offerer, collectionId, nftId) {
+    console.log(`\tWithdraw offer on Shell NFT ID [${collectionId}, ${nftId}]...`);
+    await waitExtrinsicFinished(khalaApi, khalaApi.tx.rmrkMarket.withdrawOffer(collectionId, nftId), offerer);
+}
+
 module.exports = {
     pwCreateCollection,
     setStatusType,
@@ -363,5 +407,11 @@ module.exports = {
     initializeAccountsIncubationProcess,
     simulateFeeding,
     setOriginOfShellChosenParts,
-    hatchOriginOfShell
+    hatchOriginOfShell,
+    listNft,
+    buyNft,
+    unlistNft,
+    makeOfferOnNft,
+    acceptOfferOnNft,
+    withdrawOfferOnNft
 }


### PR DESCRIPTION
## Description
Currently frontend has to execute scripts defined in `./scripts/js/pw/` to setup a local testnet, but these scripts only create a chain state for frontend to manually test. This PR will break this out into parts to allow for setting the local testnet chain state, and execute tests using `chai` and `mocha` to avoid manual tests.

## Targets
- [x] Remove redundant code & simplify the `KhalaApi` connection.
- [x] Add `chai` and `mocha` `devDependencies` to `package.json`
- [x] Decouple scripts with redundant `tx`, `query` calls into a `util/` folder with `tx.js`, `fetch.js` and `helpers.js`
- [x] Migrate current scripts into a `test` folder
- [x] Create test scenarios listed here https://www.notion.so/phalanetwork/f6242b2d04224ab19193bff6505d7d39?v=bdd28f55fd784bd8821212a5c2924e74
  - [x] Init PhalaWorld Test Cases
  - [x] Soul NFT Claim
  - [x] Origin of Shell Legendary & Magic Purchase
  - [x] Origin of Shell Whitelist Purchase
  - [x] Origin of Shell Preorders Phase 1
  - [x] Origin of Shell Preorders Phase 2
  - [x] Incubation Process
  - [x] Hatching Origin of Shell Process
  - [x] Marketplace Simulation
  - [x] Update Incubation Process w/ latest changes
- [x] Test with `yarn` commands to set up a chain state and run an automated test suite