### PR TITLE
Update incubation PartInfo with metadata database update

### DIFF
--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -488,7 +488,7 @@ pub mod pallet {
 					("name", property_value(&part_info.name)),
 					("slot_name", slot_name_value.clone()),
 					("rarity", property_value(&part_info.rarity)),
-					("race", property_value(&part_info.rarity)),
+					("race", property_value(&part_info.race)),
 					("career", property_value(&part_info.career)),
 					("sizes", property_value(&part_info.sizes)),
 					("style", property_value(&part_info.style)),
@@ -518,7 +518,7 @@ pub mod pallet {
 								("name", property_value(&sub_part_info.name)),
 								("slot_name", slot_name_value.clone()),
 								("rarity", property_value(&sub_part_info.rarity)),
-								("race", property_value(&sub_part_info.rarity)),
+								("race", property_value(&sub_part_info.race)),
 								("career", property_value(&sub_part_info.career)),
 								("sizes", property_value(&sub_part_info.sizes)),
 								("style", property_value(&sub_part_info.style)),
@@ -719,6 +719,7 @@ where
 	fn can_hatch() -> bool {
 		let now = T::Time::now().as_secs();
 		now > OfficialHatchTime::<T>::get()
+		// true
 	}
 
 	/// Helper function to get collection id Shell collection

--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -488,6 +488,10 @@ pub mod pallet {
 					("name", property_value(&part_info.name)),
 					("slot_name", slot_name_value.clone()),
 					("rarity", property_value(&part_info.rarity)),
+					("race", property_value(&part_info.rarity)),
+					("career", property_value(&part_info.career)),
+					("sizes", property_value(&part_info.sizes)),
+					("style", property_value(&part_info.style)),
 					("layer", property_value(&part_info.layer)),
 					("x", property_value(&part_info.x)),
 					("y", property_value(&part_info.y)),
@@ -514,6 +518,10 @@ pub mod pallet {
 								("name", property_value(&sub_part_info.name)),
 								("slot_name", slot_name_value.clone()),
 								("rarity", property_value(&sub_part_info.rarity)),
+								("race", property_value(&sub_part_info.rarity)),
+								("career", property_value(&sub_part_info.career)),
+								("sizes", property_value(&sub_part_info.sizes)),
+								("style", property_value(&sub_part_info.style)),
 								("layer", property_value(&sub_part_info.layer)),
 								("x", property_value(&sub_part_info.x)),
 								("y", property_value(&sub_part_info.y)),
@@ -525,7 +533,7 @@ pub mod pallet {
 								shell_parts_collection_id,
 								shell_parts_collection_id,
 								shell_part_nft_id,
-								false,
+								sub_part_info.tradeable,
 							)?;
 						}
 					}

--- a/pallets/phala-world/src/tests.rs
+++ b/pallets/phala-world/src/tests.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use crate::mock::*;
 use codec::Encode;
+use frame_support::bounded_vec;
 use frame_support::{assert_noop, assert_ok, error::BadOrigin, traits::Currency};
 use sp_core::{crypto::AccountId32, sr25519, Pair};
 use sp_runtime::BoundedVec;
@@ -12,7 +13,7 @@ use sp_runtime::BoundedVec;
 use crate::incubation::{ShellPartInfoOf, ShellPartsOf};
 use crate::traits::{
 	primitives::*, CareerType, NftSaleType, OverlordMessage, PartInfo, Purpose, RaceType,
-	RarityType, ShellPartInfo, ShellParts, StatusType,
+	RarityType, PartRarityType, PartSizeType, ShellPartInfo, ShellParts, StatusType
 };
 use mock::{
 	Event as MockEvent, ExtBuilder, Origin, PWIncubation, PWNftSale, RmrkCore, RmrkMarket, Test,
@@ -181,7 +182,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 	let shell_part_info1: ShellPartInfoOf<Test> = ShellPartInfo {
 		shell_part: PartInfo {
 			name: stb("jacket"),
-			rarity: RarityType::Magic,
+			rarity: PartRarityType::Normal,
+			race: Some(RaceType::Cyborg),
+			career: Some(CareerType::HackerWizard),
+			sizes: Some(bounded_vec![PartSizeType::MA]),
+			style: Some(stb("Sg01")),
 			metadata: None,
 			layer: 0,
 			x: 0,
@@ -191,7 +196,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 		sub_parts: Some(bvec![
 			PartInfo {
 				name: stb("jacket-details"),
-				rarity: RarityType::Legendary,
+				rarity: PartRarityType::Legend,
+				race: None,
+				career: Some(CareerType::HackerWizard),
+				sizes: Some(bounded_vec![PartSizeType::MA]),
+				style: Some(stb("Sg01")),
 				metadata: Some(stb("ar://jacket-details-uri")),
 				layer: 0,
 				x: 0,
@@ -200,7 +209,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 			},
 			PartInfo {
 				name: stb("jacket"),
-				rarity: RarityType::Prime,
+				rarity: PartRarityType::Epic,
+				race: None,
+				career: Some(CareerType::HackerWizard),
+				sizes: Some(bounded_vec![PartSizeType::MA]),
+				style: Some(stb("Sg01")),
 				metadata: Some(stb("ar://jacket-uri")),
 				layer: 0,
 				x: 0,
@@ -209,7 +222,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 			},
 			PartInfo {
 				name: stb("jacket-hat"),
-				rarity: RarityType::Magic,
+				rarity: PartRarityType::Epic,
+				race: None,
+				career: Some(CareerType::HackerWizard),
+				sizes: Some(bounded_vec![PartSizeType::MA]),
+				style: Some(stb("Sg01")),
 				metadata: Some(stb("ar://jacket-hat-uri")),
 				layer: 0,
 				x: 0,
@@ -221,7 +238,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 	let shell_part_info2 = ShellPartInfo {
 		shell_part: PartInfo {
 			name: stb("t_shirt"),
-			rarity: RarityType::Prime,
+			rarity: PartRarityType::Normal,
+			race: None,
+			career: Some(CareerType::HackerWizard),
+			sizes: Some(bounded_vec![PartSizeType::MA]),
+			style: Some(stb("Sg01")),
 			metadata: Some(stb("ar://t-shirt-uri")),
 			layer: 0,
 			x: 0,
@@ -233,7 +254,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 	let shell_part_info3 = ShellPartInfo {
 		shell_part: PartInfo {
 			name: stb("shoes"),
-			rarity: RarityType::Prime,
+			rarity: PartRarityType::Rare,
+			race: None,
+			career: Some(CareerType::HackerWizard),
+			sizes: Some(bounded_vec![PartSizeType::MA]),
+			style: Some(stb("Sg01")),
 			metadata: None,
 			layer: 0,
 			x: 0,
@@ -243,7 +268,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 		sub_parts: Some(bvec![
 			PartInfo {
 				name: stb("shoes-details"),
-				rarity: RarityType::Magic,
+				rarity: PartRarityType::Epic,
+				race: None,
+				career: Some(CareerType::HackerWizard),
+				sizes: Some(bounded_vec![PartSizeType::MA]),
+				style: Some(stb("Sg01")),
 				metadata: Some(stb("ar://shoes-details-uri")),
 				layer: 0,
 				x: 0,
@@ -252,7 +281,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 			},
 			PartInfo {
 				name: stb("shoes"),
-				rarity: RarityType::Prime,
+				rarity: PartRarityType::Normal,
+				race: None,
+				career: Some(CareerType::HackerWizard),
+				sizes: Some(bounded_vec![PartSizeType::MA]),
+				style: Some(stb("Sg01")),
 				metadata: Some(stb("ar://shoes-uri")),
 				layer: 0,
 				x: 0,
@@ -264,7 +297,11 @@ fn get_shell_part(shell_part_type: u8) -> ShellPartsOf<Test> {
 	let shell_part_info4 = ShellPartInfo {
 		shell_part: PartInfo {
 			name: stb("head"),
-			rarity: RarityType::Prime,
+			rarity: PartRarityType::Normal,
+			race: Some(RaceType::Cyborg),
+			career: Some(CareerType::HackerWizard),
+			sizes: Some(bounded_vec![PartSizeType::MA]),
+			style: Some(stb("Sg01")),
 			metadata: Some(stb("ar://head-uri")),
 			layer: 0,
 			x: 0,

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -150,12 +150,9 @@ pub struct FoodInfo<BoundedOriginOfShellsFed> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ShellPartInfo<BoundedString, BoundedSubParts> {
 	pub shell_part: PartInfo<BoundedString>,
-	// pub shell_part: BoundedPartInfo,
 	/// If Metadata is None then this is a BoundedVec of ShellSubPartInfo that compose the Part
 	pub sub_parts: Option<BoundedSubParts>,
 }
-
-pub struct SizesMaxLen;
 
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -157,12 +157,6 @@ pub struct ShellPartInfo<BoundedString, BoundedSubParts> {
 
 pub struct SizesMaxLen;
 
-impl Get<u32> for SizesMaxLen {
-	fn get() -> u32 {
-		4
-	}
-}
-
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct PartInfo<BoundedString> {
@@ -175,7 +169,7 @@ pub struct PartInfo<BoundedString> {
 	/// Restriction for Shell Career, None is no restriction.
 	pub career: Option<CareerType>,
 	/// Restriction for shell Sizes, None is no restriction.
-	pub sizes: Option<BoundedVec<PartSizeType, SizesMaxLen>>,
+	pub sizes: Option<BoundedVec<PartSizeType, ConstU32<4>>>,
 	/// Style Code for Part
 	pub style: Option<BoundedString>,
 	/// Metadata is None if the Part is composed of Sub-Parts

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -48,6 +48,36 @@ pub enum RarityType {
 	Legendary,
 }
 
+/// Shell Part Rarity Types of Normal, Rare, Epic, Legend
+#[derive(Encode, Decode, Clone, Copy, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum PartRarityType {
+	Normal,
+	Rare,
+	Epic,
+	Legend,
+}
+
+/// Shell Part Sizes. For each race:
+/// Cyborg have two sizes: MA, MB
+/// X-Gene have three sizes: XA, XB, XC
+/// Pandroid have four sizes: PA, PB, PC, PD
+/// Ai Spectre only got one size: AA
+#[derive(Encode, Decode, Clone, Copy, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum PartSizeType {
+	MA,
+	MB,
+	XA,
+	XB,
+	XC,
+	PA,
+	PB,
+	PC,
+	PD,
+	AA,
+}
+
 /// Race types
 #[derive(Encode, Decode, Debug, Clone, Copy, Eq, PartialEq, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
@@ -120,8 +150,17 @@ pub struct FoodInfo<BoundedOriginOfShellsFed> {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct ShellPartInfo<BoundedString, BoundedSubParts> {
 	pub shell_part: PartInfo<BoundedString>,
+	// pub shell_part: BoundedPartInfo,
 	/// If Metadata is None then this is a BoundedVec of ShellSubPartInfo that compose the Part
 	pub sub_parts: Option<BoundedSubParts>,
+}
+
+pub struct SizesMaxLen;
+
+impl Get<u32> for SizesMaxLen {
+	fn get() -> u32 {
+		4
+	}
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo, MaxEncodedLen)]
@@ -130,7 +169,15 @@ pub struct PartInfo<BoundedString> {
 	/// Name of the Part
 	pub name: BoundedString,
 	/// Shell part rarity type
-	pub rarity: RarityType,
+	pub rarity: PartRarityType,
+	/// Restrictiion for Shell Race, None is no restriction.
+	pub race: Option<RaceType>,
+	/// Restriction for Shell Career, None is no restriction.
+	pub career: Option<CareerType>,
+	/// Restriction for shell Sizes, None is no restriction.
+	pub sizes: Option<BoundedVec<PartSizeType, SizesMaxLen>>,
+	/// Style Code for Part
+	pub style: Option<BoundedString>,
 	/// Metadata is None if the Part is composed of Sub-Parts
 	pub metadata: Option<BoundedString>,
 	/// Layer in the png file

--- a/scripts/js/pw/startIncubationProcess.js
+++ b/scripts/js/pw/startIncubationProcess.js
@@ -149,87 +149,274 @@ async function main() {
     }
     console.log(topTenFed.toString());
 
-    const jacketChosenPart = {
-        'parts': {
+    const CyborgChosenParts = {
+        "parts": {
+            "weapon":  {
+                "shell_part": {
+                    "name": "Weapon",
+                    "metadata": null,
+                    "layer": 0,
+                    'x': 0,
+                    'y': 0,
+                },
+                "sub_parts": [
+                    {
+                        "name": "lightsaber",
+                        "rarity": "Normal",
+                        "career": "RoboWarrior",
+                        "style": "Sg01",
+                        "layer": 19,
+                        "metadata": "pw://weapon/lighsaber",
+                        "tradeable": true,
+                    },
+                    {
+                        "name": "Sniper Rifle",
+                        "rarity": "Rare",
+                        "career": "RoboWarrior",
+                        "style": "Sp01",
+                        "layer": 20,
+                        "metadata": "pw://weapon/sniper-rifle",
+                        "tradeable": true,
+                    },
+                ]
+            },
+            "body": {
+                "shell_part": {
+                    "name": "Body",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA"],
+                    "layer": 0,
+                    'x': 0,
+                    'y': 0,
+                },
+                "sub_parts": [
+                    {
+                        "name": "Short Hair",
+                        "style": "Sg01",
+                        "rarity": "Normal",
+                        "metadata": "pw://body/hair/short-hair",
+                        "layer": 2,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    {
+                        "name": "Human Eyes",
+                        "rarity": "Normal",
+                        "metadata": "pw://body/eyes/human-eyes",
+                        "layer": 4,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    {
+                        "name": "Male Head 01",
+                        "style": "Skin01",
+                        "rarity": "Normal",
+                        "metadata": "pw://body/head/male-head-01",
+                        "layer": 6,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    {
+                        "name": "Male Body 01",
+                        "style": "Skin01",
+                        "rarity": "Normal",
+                        "metadata": "pw://body/body/male-body-01",
+                        "layer": 16,
+                        'x': 0,
+                        'y': 0,
+                    },
+                ],
+            },
+            "jaw": {
+                "shell_part": {
+                    "name": "Cyborg Jaw(Neck)",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA"],
+                    "style": "Me01",
+                    "metadata": "pw://jaw",
+                    "layer": 3,
+                    'x': 0,
+                    'y': 0,
+                    "tradeable": true,
+                },
+            },
+            "tattoo": {
+                "shell_part": {
+                    "name": "Cyberpsychosis Tatoo",
+                    "rarity": "Epic",
+                    "race": "Cyborg",
+                    "sizes": ["MA"],
+                    "style": "Sp01",
+                    "metadata": "pw://tattoo",
+                    "layer": 5,
+                    'x': 0,
+                    'y': 0,
+                    "tradeable": true,
+                },
+            },
             "jacket": {
-                'shell_part': {
-                    'name': "jacket",
-                    'rarity': 'Magic',
-                    'metadata': null,
-                    'layer': 0,
+                "shell_part": {
+                    "name": "Jacket",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA", "MB"],
+                    "layer": 0,
                     'x': 0,
                     'y': 0,
+                    "tradeable": true,
                 },
-                'sub_parts': [
+                "sub_parts": [
                     {
-                        'name': "jacket-details",
-                        'rarity': 'Legendary',
-                        'metadata': "ar://jacket-details-uri",
-                        'layer': 0,
+                        "name": "White Buckle",
+                        "rarity": "Normal",
+                        "style": "Sg01",
+                        "metadata": "pw://jacket/jacket_details",
+                        "layer": 7,
                         'x': 0,
-                        'y': 0
+                        'y': 0,
                     },
                     {
-                        'name': "jacket-hat",
-                        'rarity': 'Magic',
-                        'metadata': "ar://jacket-hat-uri",
-                        'layer': 0,
+                        "name": "Solid Jacket",
+                        "rarity": "Normal",
+                        "style": "Sg01",
+                        "metadata": "pw://jacket/jacket",
+                        "layer": 8,
                         'x': 0,
-                        'y': 0
+                        'y': 0,
                     },
                     {
-                        'name': "jacket",
-                        'rarity': 'Prime',
-                        'metadata': "ar://jacket-uri",
-                        'layer': 0,
+                        "name": "Lightspeed Hood",
+                        "rarity": "Legend",
+                        "style": "Sp01",
+                        "metadata": "pw://jacket/hood",
+                        "layer": 17,
                         'x': 0,
-                        'y': 0
-                    }
+                        'y': 0,
+                    },
+                    {
+                        "name": "Solid Jacket",
+                        "rarity": "Normal",
+                        "style": "Sg01",
+                        "metadata": "pw://jacket/jacketun",
+                        "layer": 18,
+                        'x': 0,
+                        'y': 0,
+                    },
                 ],
             },
-            't_shirt': {
-                'shell_part': {
-                    'name': 't_shirt',
-                    'rarity': 'Prime',
-                    'metadata': "ar://t-shirt-uri",
-                    'layer': 0,
+            "bionic_arm": {
+                "shell_part": {
+                    "name": "Black Bionic Arm",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA", "MB"],
+                    "style": "Sg01",
+                    "metadata": "pw://bionic_arm",
+                    "layer": 9,
                     'x': 0,
                     'y': 0,
+                    "tradeable": true,
                 },
-                'sub_parts': null,
             },
-            'shoes': {
-                'shell_part': {
-                    'name': "shoes",
-                    'rarity': 'Prime',
-                    'metadata': null,
-                    'layer': 0,
+            "shirt": {
+                "shell_part": {
+                    "name": "Cyborg's symbol T-Shirt",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA", "MB"],
+                    "style": "Sg07",
+                    "metadata": "pw://shirt",
+                    "layer": 10,
                     'x': 0,
                     'y': 0,
+                    "tradeable": true,
                 },
-                'sub_parts': [
+            },
+            "shorts": {
+                "shell_part": {
+                    "name": "Shorts",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA", "MB"],
+                    "metadata": null,
+                    "layer": 0,
+                    'x': 0,
+                    'y': 0,
+                    "tradeable": true,
+                },
+                "sub_parts": [
                     {
-                        'name': "shoes-details",
-                        'rarity': 'Prime',
-                        'metadata': "ar://shoes-details-uri",
-                        'layer': 0,
+                        "name": "Black Buckle",
+                        "rarity": "Normal",
+                        "style": "Sg01",
+                        "metadata": "pw://shorts/shorts-details",
+                        "layer": 11,
                         'x': 0,
-                        'y': 0
+                        'y': 0,
                     },
                     {
-                        'name': "shoes",
-                        'rarity': 'Prime',
-                        'metadata': "ar://shoes-uri",
-                        'layer': 0,
+                        "name": "Solid Shorts",
+                        "rarity": "Normal",
+                        "style": "Sg01",
+                        "metadata": "pw://shorts/shorts",
+                        "layer": 12,
                         'x': 0,
-                        'y': 0
-                    }
+                        'y': 0,
+                    },
                 ],
-            }
-        }
+            },
+            "feet": {
+                "shell_part": {
+                    "name": "Feet",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA", "MB"],
+                    "layer": 0,
+                    'x': 0,
+                    'y': 0,
+                    "tradeable": true,
+                },
+                "sub_parts": [
+                    {
+                        "name": "Solid Shorts Buckle",
+                        "rarity": "Normal",
+                        "style": "Sg04",
+                        "metadata": "pw://feet/shoes-ribbon",
+                        "layer": 13,
+                        'x': 0,
+                        'y': 0,
+                    },
+                    {
+                        "name": "Black Fade Shorts",
+                        "rarity": "Epic",
+                        "style": "Gc02",
+                        "metadata": "pw://feet/shoes",
+                        "layer": 14,
+                        'x': 0,
+                        'y': 0,
+                    }
+                ]
+            },
+            "bionic_leg": {
+                "shell_part": {
+                    "name": "Black Bionic Leg",
+                    "rarity": "Normal",
+                    "race": "Cyborg",
+                    "sizes": ["MA", "MB"],
+                    "style": "Sg01",
+                    "metadata": "pw://bionic_leg",
+                    "layer": 15,
+                    'x': 0,
+                    'y': 0,
+                    "tradeable": true,
+                },
+            },
+        },
     };
     // Set chosen part for NFT ID 0
-    await setOriginOfShellChosenParts(api, overlord, 1, 0, jacketChosenPart);
+    await setOriginOfShellChosenParts(api, overlord, 1, 0, CyborgChosenParts);
 
 }
 


### PR DESCRIPTION
Last week we redesign the metadata database based on the new designs and add more attributes to support the "dress up" feature in the future.

The incubation process demo script has been updated as well, I'd add sample data for Cyborg, and it should be very close to the final synthesis result. The sample data may be related to #184.

Question: do we need sample data for remain three races? I haven't create those yet.