### PR TITLE
[DON'T MERGE] V0.1.18-3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "khala-node"
-version = "0.1.18-2"
+version = "0.1.18-3"
 dependencies = [
  "async-trait",
  "clap",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "khala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -6739,7 +6739,7 @@ dependencies = [
 
 [[package]]
 name = "phala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "rhala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -11574,7 +11574,7 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3672,7 +3672,7 @@ dependencies = [
 
 [[package]]
 name = "khala-node"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 dependencies = [
  "async-trait",
  "clap",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "khala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -6739,7 +6739,7 @@ dependencies = [
 
 [[package]]
 name = "phala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "rhala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -11574,7 +11574,7 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-node"
-version = "0.1.18-2"
+version = "0.1.18-3"
 license = "Apache-2.0"
 homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/khala-parachain"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-node"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 license = "Apache-2.0"
 homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/khala-parachain"

--- a/pallets/phala/src/stakepool.rs
+++ b/pallets/phala/src/stakepool.rs
@@ -332,7 +332,7 @@ pub mod pallet {
 		/// A staker is removed from the pool contribution whitelist
 		PoolWhitelistStakerRemoved { pid: u64, staker: T::AccountId },
 		/// A worker is reclaimed from the pool
-		WorkerReclaimed { pid: u64, worker: WorkerPublicKey },
+		WorkerReclaimed { pid: u64, worker: WorkerPublicKey, original_stake: BalanceOf<T> },
 		/// The amount of reward that distributed to owner and stakers
 		RewardReceived {
 			pid: u64,
@@ -1064,8 +1064,8 @@ pub mod pallet {
 			// Stop and instantly reclaim the worker
 			Self::do_stop_mining(&owner, pid, worker)?;
 			let miner: T::AccountId = pool_sub_account(pid, &worker);
-			let (orig_stake, slashed) = Self::do_reclaim(pid, miner, worker, false)?;
-			let released = orig_stake - slashed;
+			let (original_stake, slashed) = Self::do_reclaim(pid, miner, worker, false)?;
+			let released = original_stake - slashed;
 			ensure!(stake > released, Error::<T>::CannotRestartWithLessStake);
 			// Simply start mining. Rollback if there's no enough stake,
 			Self::do_start_mining(&owner, pid, worker, stake)
@@ -1133,11 +1133,11 @@ pub mod pallet {
 			worker: WorkerPublicKey,
 			check_cooldown: bool,
 		) -> Result<(BalanceOf<T>, BalanceOf<T>), DispatchError> {
-			let (orig_stake, slashed) =
+			let (original_stake, slashed) =
 				mining::Pallet::<T>::reclaim(sub_account.clone(), check_cooldown)?;
-			Self::handle_reclaim(pid, orig_stake, slashed);
-			Self::deposit_event(Event::<T>::WorkerReclaimed { pid, worker });
-			Ok((orig_stake, slashed))
+			Self::handle_reclaim(pid, original_stake, slashed);
+			Self::deposit_event(Event::<T>::WorkerReclaimed { pid, worker, original_stake });
+			Ok((original_stake, slashed))
 		}
 
 		/// Adds up the newly received reward to `reward_acc`
@@ -1182,10 +1182,10 @@ pub mod pallet {
 		///
 		/// After the cool down ends, worker was cleaned up, whose contributed balance would be
 		/// reset to zero.
-		fn handle_reclaim(pid: u64, orig_stake: BalanceOf<T>, slashed: BalanceOf<T>) {
+		fn handle_reclaim(pid: u64, original_stake: BalanceOf<T>, slashed: BalanceOf<T>) {
 			let mut pool_info = Self::ensure_pool(pid).expect("Stake pool must exist; qed.");
 
-			let returned = orig_stake - slashed;
+			let returned = original_stake - slashed;
 			if slashed != Zero::zero() {
 				// Remove some slashed value from `total_stake`, causing the share price to reduce
 				// and creating a logical pending slash. The actual slash happens with the pending
@@ -1542,11 +1542,11 @@ pub mod pallet {
 		BalanceOf<T>: FixedPointConvert + Display,
 	{
 		/// Called when a worker is stopped and there is releasing stake
-		fn on_stopped(worker: &WorkerPublicKey, orig_stake: BalanceOf<T>, slashed: BalanceOf<T>) {
+		fn on_stopped(worker: &WorkerPublicKey, original_stake: BalanceOf<T>, slashed: BalanceOf<T>) {
 			let pid = WorkerAssignments::<T>::get(worker)
 				.expect("Stopping workers have assignment; qed.");
 			let mut pool_info = Self::ensure_pool(pid).expect("Stake pool must exist; qed.");
-			let returned = orig_stake - slashed;
+			let returned = original_stake - slashed;
 			pool_info.releasing_stake.saturating_accrue(returned);
 			StakePools::<T>::insert(pid, pool_info);
 		}
@@ -3845,7 +3845,7 @@ pub mod pallet {
 					0,
 					500 * DOLLARS
 				));
-				let orig_pool = StakePools::<Test>::get(0);
+				let original_pool = StakePools::<Test>::get(0);
 				StakePools::<Test>::mutate(0, |pool_info| {
 					pool_info
 						.as_mut()
@@ -3890,7 +3890,7 @@ pub mod pallet {
 					0,
 					500 * DOLLARS
 				));
-				let orig_pool = StakePools::<Test>::get(0);
+				let original_pool = StakePools::<Test>::get(0);
 				StakePools::<Test>::mutate(0, |pool_info| {
 					pool_info
 						.as_mut()

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 4,
+    transaction_version: 5,
     state_version: 0,
 };
 

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -145,7 +145,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("khala"),
     impl_name: create_runtime_str!("khala"),
     authoring_version: 1,
-    spec_version: 1182,
+    spec_version: 1183,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 5,

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -145,7 +145,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("khala"),
     impl_name: create_runtime_str!("khala"),
     authoring_version: 1,
-    spec_version: 1186,
+    spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/phala/Cargo.toml
+++ b/runtime/phala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/phala/Cargo.toml
+++ b/runtime/phala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("phala"),
     impl_name: create_runtime_str!("phala"),
     authoring_version: 1,
-    spec_version: 1182,
+    spec_version: 1183,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -142,7 +142,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 3,
+    transaction_version: 4,
     state_version: 0,
 };
 

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("phala"),
     impl_name: create_runtime_str!("phala"),
     authoring_version: 1,
-    spec_version: 1186,
+    spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -147,7 +147,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("rhala"),
     impl_name: create_runtime_str!("rhala"),
     authoring_version: 1,
-    spec_version: 1186,
+    spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -150,7 +150,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 4,
+    transaction_version: 5,
     state_version: 0,
 };
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -147,7 +147,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("rhala"),
     impl_name: create_runtime_str!("rhala"),
     authoring_version: 1,
-    spec_version: 1182,
+    spec_version: 1183,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 5,

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thala-parachain-runtime"
-version = "0.1.19-dev"
+version = "0.1.18-2"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thala-parachain-runtime"
-version = "0.1.18-2"
+version = "0.1.18-3"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -151,7 +151,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
-    transaction_version: 4,
+    transaction_version: 5,
     state_version: 0,
 };
 

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("thala"),
     impl_name: create_runtime_str!("thala"),
     authoring_version: 1,
-    spec_version: 1182,
+    spec_version: 1183,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 5,

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("thala"),
     impl_name: create_runtime_str!("thala"),
     authoring_version: 1,
-    spec_version: 1186,
+    spec_version: 1182,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,


### PR DESCRIPTION
Only for the CI

- Bump `transaction_version` https://github.com/paritytech/cumulus/pull/1647
  - We should do this in v0.1.18 release, but missed it, upstream has a discussion about how to automatic check bumping `transacion_version` https://github.com/paritytech/cumulus/issues/1686
 - Backport https://github.com/Phala-Network/phala-blockchain/pull/1002
 - Spec version bump to 1183
 - Node version bump to v0.1.18-3