### PR TITLE
Add initial migration implementation for updates from RMRK.

### DIFF
--- a/pallets/phala-world/src/incubation.rs
+++ b/pallets/phala-world/src/incubation.rs
@@ -365,8 +365,8 @@ pub mod pallet {
 		/// NFT.
 		///
 		/// Parameters:
-		/// - `origin`: The origin of the extrinsic incubation the origin_of_shell
-		/// - `collection_id`: The collection id of the Origin of Shell RMRK NFT
+		/// - `origin`: Expected to be the `Overlord` account
+        /// - `collection_id`: The collection id of the Origin of Shell RMRK NFT
 		/// - `nft_id`: The NFT id of the Origin of Shell RMRK NFT
 		/// - `default_shell_metadata`: File resource URI in decentralized storage for Shell NFT
 		///	parts that render the Shell NFT
@@ -378,6 +378,7 @@ pub mod pallet {
 			nft_id: NftId,
 			default_shell_metadata: BoundedVec<u8, T::StringLimit>,
 		) -> DispatchResult {
+            // Ensure Overlord account is the sender
 			let sender = ensure_signed(origin.clone())?;
 			pallet_pw_nft_sale::pallet::Pallet::<T>::ensure_overlord(&sender)?;
 			// Check if Incubation Phase has started

--- a/pallets/phala-world/src/migration.rs
+++ b/pallets/phala-world/src/migration.rs
@@ -2,7 +2,44 @@ use super::*;
 
 mod phala_world_migration_common {
 	use super::*;
-	use frame_support::traits::StorageVersion;
+	use codec::{Decode, Encode};
+	use frame_support::pallet_prelude::*;
+	use frame_support::{
+		log,
+		traits::StorageVersion,
+		BoundedVec,
+	};
+	use pallet_rmrk_core::Collections;
+	use rmrk_traits::{primitives::CollectionId, AccountIdOrCollectionNftTuple, RoyaltyInfo};
+	use scale_info::TypeInfo;
+	#[cfg(feature = "std")]
+	use serde::Serialize;
+	use sp_runtime::Permill;
+
+	#[cfg_attr(feature = "std", derive(PartialEq, Eq, Serialize))]
+	#[derive(Encode, Decode, Debug, TypeInfo, MaxEncodedLen)]
+	pub struct OldNftInfo<AccountId, RoyaltyAmount, BoundedString, CollectionId, NftId> {
+		/// The owner of the NFT, can be either an Account or a tuple (CollectionId, NftId)
+		pub owner: AccountIdOrCollectionNftTuple<AccountId, CollectionId, NftId>,
+		/// Royalty (optional)
+		pub royalty: Option<RoyaltyInfo<AccountId, RoyaltyAmount>>,
+		/// Arbitrary data about an instance, e.g. IPFS hash
+		pub metadata: BoundedString,
+		/// Equipped state
+		pub equipped: bool,
+		/// Pending state (if sent to NFT)
+		pub pending: bool,
+		/// transferability ( non-transferable is "souldbound" )
+		pub transferable: bool,
+	}
+
+	pub type OldInstanceInfoOf<T> = OldNftInfo<
+		<T as frame_system::Config>::AccountId,
+		Permill,
+		BoundedVec<u8, <T as pallet_uniques::Config>::StringLimit>,
+		<T as pallet_uniques::Config>::CollectionId,
+		<T as pallet_uniques::Config>::ItemId,
+	>;
 
 	pub type Versions = (
 		// Version for NFT Sale pallet
@@ -37,14 +74,6 @@ mod phala_world_migration_common {
 			StorageVersion::get::<pallet_uniques::Pallet<T>>(),
 		)
 	}
-}
-
-pub mod phala_world_migration {
-	use super::*;
-	use frame_support::traits::StorageVersion;
-	use frame_support::{ensure, log, traits::Get};
-	use pallet_rmrk_core::Collections;
-	use phala_world_migration_common as common;
 
 	pub fn get_next_collection_id<T>() -> (u32, u64)
 	where
@@ -52,18 +81,140 @@ pub mod phala_world_migration {
 			+ pallet_rmrk_core::Config
 			+ pallet_uniques::Config<CollectionId = u32>,
 	{
-		let mut next_collection_id: u32 = 0;
 		let mut reads: u64 = 0;
-		for collection_id in pallet_rmrk_core::Collections::<T>::iter_keys() {
-			if collection_id > next_collection_id {
-				next_collection_id = collection_id;
+		let next_collection_id: u32 = match frame_support::migration::take_storage_value::<
+			CollectionId,
+		>(b"RmrkCore", b"CollectionIndex", &[])
+		{
+			Some(next_collection_id) => {
+				reads += 1;
+				log::info!("NextCollectionId == {}", next_collection_id);
+				next_collection_id
 			}
-			reads += 1;
-		}
-		// Add 1 to the next_collection_id
-		next_collection_id += 1;
+			None => {
+				log::info!("NextCollectionId NOT detected");
+				0
+			}
+		};
+
 		(next_collection_id, reads)
 	}
+
+	pub fn get_old_nft_count_in_collection<T>(next_collection_id: CollectionId) -> u32
+	where
+		T: pallet_pw_nft_sale::Config
+			+ pallet_rmrk_core::Config
+			+ pallet_uniques::Config<CollectionId = u32>,
+	{
+		let mut count = 0;
+		let mut collection_id = 0;
+		while collection_id < next_collection_id {
+			let collection_nft_count = match Collections::<T>::get(collection_id) {
+				Some(collection_info_of) => collection_info_of.nfts_count,
+				None => 0,
+			};
+			count += collection_nft_count;
+			collection_id += 1;
+		}
+		count
+	}
+}
+
+pub mod phala_world_migration_rhala {
+	use super::*;
+	use common::{get_next_collection_id, get_old_nft_count_in_collection, OldInstanceInfoOf};
+	use frame_support::traits::StorageVersion;
+	use frame_support::{ensure, log, traits::Get};
+	use pallet_rmrk_core::Nfts;
+	use phala_world_migration_common as common;
+	use rmrk_traits::{
+		primitives::{CollectionId, NftId},
+		NftInfo,
+	};
+
+	pub fn pre_migrate<T>() -> Result<(), &'static str>
+		where
+			T: pallet_pw_nft_sale::Config
+			+ pallet_rmrk_core::Config
+			+ pallet_uniques::Config<CollectionId = u32>,
+	{
+		ensure!(
+			common::get_versions::<T>() == common::EXPECTED_KHALA_STORAGE_VERSION,
+			"Incorrect PhalaWorld storage version in pre migrate"
+		);
+		log::info!("PhalaWorld pre migration check passed👏");
+		Ok(())
+	}
+
+	pub fn migrate<T>() -> frame_support::weights::Weight
+		where
+			T: pallet_pw_nft_sale::Config
+			+ pallet_rmrk_core::Config
+			+ pallet_uniques::Config<CollectionId = u32, ItemId = NftId>,
+	{
+		if common::get_versions::<T>() == common::EXPECTED_KHALA_STORAGE_VERSION {
+			log::info!("Start PhalaWorld migration");
+
+			let (next_collection_id, reads) = get_next_collection_id::<T>();
+			let expected_writes = get_old_nft_count_in_collection::<T>(next_collection_id);
+			log::info!("Expected writes: {}", expected_writes);
+			log::info!("Start translate of Nfts StorageDoubleMap");
+			Nfts::<T>::translate(
+				|_collection_id: CollectionId,
+				 _nft_id: NftId,
+				 old_instance_info_of: OldInstanceInfoOf<T>| {
+					Some(NftInfo {
+						owner: old_instance_info_of.owner,
+						royalty: old_instance_info_of.royalty,
+						metadata: old_instance_info_of.metadata,
+						equipped: None,
+						pending: old_instance_info_of.pending,
+						transferable: old_instance_info_of.transferable,
+					})
+				},
+			);
+
+			log::info!("Insert {} into NextCollectionId", next_collection_id);
+			pallet_pw_nft_sale::NextCollectionId::<T>::put(next_collection_id);
+			// Set new storage version
+			StorageVersion::new(2).put::<pallet_pw_nft_sale::Pallet<T>>();
+			StorageVersion::new(2).put::<pallet_rmrk_core::Pallet<T>>();
+			StorageVersion::new(2).put::<pallet_uniques::Pallet<T>>();
+
+			log::info!("PhalaWorld migration done👏");
+			T::DbWeight::get().reads_writes(reads, expected_writes.into())
+		} else {
+			T::DbWeight::get().reads(1)
+		}
+	}
+
+	pub fn post_migrate<T>() -> Result<(), &'static str>
+		where
+			T: pallet_pw_nft_sale::Config
+			+ pallet_rmrk_core::Config
+			+ pallet_uniques::Config<CollectionId = u32>,
+	{
+		ensure!(
+			common::get_versions::<T>() == common::FINAL_STORAGE_VERSION,
+			"Incorrect PhalaWorld storage version in post migrate"
+		);
+		log::info!("PhalaWorld post migration check passed👏");
+
+		Ok(())
+	}
+}
+
+pub mod phala_world_migration_khala {
+	use super::*;
+	use common::{get_next_collection_id, get_old_nft_count_in_collection, OldInstanceInfoOf};
+	use frame_support::traits::StorageVersion;
+	use frame_support::{ensure, log, traits::Get};
+	use pallet_rmrk_core::Nfts;
+	use phala_world_migration_common as common;
+	use rmrk_traits::{
+		primitives::{CollectionId, NftId},
+		NftInfo,
+	};
 
 	pub fn pre_migrate<T>() -> Result<(), &'static str>
 	where
@@ -83,12 +234,30 @@ pub mod phala_world_migration {
 	where
 		T: pallet_pw_nft_sale::Config
 			+ pallet_rmrk_core::Config
-			+ pallet_uniques::Config<CollectionId = u32>,
+			+ pallet_uniques::Config<CollectionId = u32, ItemId = NftId>,
 	{
 		if common::get_versions::<T>() == common::EXPECTED_KHALA_STORAGE_VERSION {
 			log::info!("Start PhalaWorld migration");
 
 			let (next_collection_id, reads) = get_next_collection_id::<T>();
+			let expected_writes = get_old_nft_count_in_collection::<T>(next_collection_id);
+			log::info!("Expected writes: {}", expected_writes);
+			log::info!("Start translate of Nfts StorageDoubleMap");
+			Nfts::<T>::translate(
+				|_collection_id: CollectionId,
+				 _nft_id: NftId,
+				 old_instance_info_of: OldInstanceInfoOf<T>| {
+					Some(NftInfo {
+						owner: old_instance_info_of.owner,
+						royalty: old_instance_info_of.royalty,
+						metadata: old_instance_info_of.metadata,
+						equipped: None,
+						pending: old_instance_info_of.pending,
+						transferable: old_instance_info_of.transferable,
+					})
+				},
+			);
+
 			log::info!("Insert {} into NextCollectionId", next_collection_id);
 			pallet_pw_nft_sale::NextCollectionId::<T>::put(next_collection_id);
 			// Set new storage version
@@ -97,7 +266,7 @@ pub mod phala_world_migration {
 			StorageVersion::new(2).put::<pallet_uniques::Pallet<T>>();
 
 			log::info!("PhalaWorld migration done👏");
-			T::DbWeight::get().reads_writes(reads, 1)
+			T::DbWeight::get().reads_writes(reads, expected_writes.into())
 		} else {
 			T::DbWeight::get().reads(1)
 		}

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -873,7 +873,7 @@ parameter_types! {
     pub const ResourceSymbolLimit: u32 = 10;
     pub const MaxPriorities: u32 = 25;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const NestingBudget: u32 = 20;
+    pub const NestingBudget: u32 = 200;
 }
 
 impl pallet_rmrk_core::Config for Runtime {

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -122,6 +122,7 @@ pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+use crate::migrations::PhalaWorldKhalaMigrations;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -203,7 +204,7 @@ pub type Executive = frame_executive::Executive<
 >;
 /// All migrations executed on runtime upgrade as a nested tuple of types implementing
 /// `OnRuntimeUpgrade`.
-type Migrations = ();
+type Migrations = PhalaWorldKhalaMigrations;
 
 type EnsureRootOrHalfCouncil = EitherOfDiverse<
     EnsureRoot<AccountId>,

--- a/runtime/khala/src/migrations.rs
+++ b/runtime/khala/src/migrations.rs
@@ -2,11 +2,11 @@
 use super::*;
 #[allow(unused_imports)]
 use frame_support::traits::OnRuntimeUpgrade;
-pub struct PhalaWorldMigrations;
+pub struct PhalaWorldKhalaMigrations;
 
-impl OnRuntimeUpgrade for PhalaWorldMigrations {
+impl OnRuntimeUpgrade for PhalaWorldKhalaMigrations {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        pallet_phala_world::migration::phala_world_migration::migrate::<Runtime>()
+        pallet_phala_world::migration::phala_world_migration_khala::migrate::<Runtime>()
     }
 }
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -124,6 +124,7 @@ pub use pallet_sudo::Call as SudoCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+use crate::migrations::PhalaWorldRhalaMigrations;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -201,7 +202,12 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    Migrations,
 >;
+
+/// All migrations executed on runtime upgrade as a nested tuple of types implementing
+/// `OnRuntimeUpgrade`.
+type Migrations = PhalaWorldRhalaMigrations;
 
 type EnsureRootOrHalfCouncil = EitherOfDiverse<
     EnsureRoot<AccountId>,

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -873,7 +873,7 @@ parameter_types! {
     pub const ResourceSymbolLimit: u32 = 10;
     pub const MaxPriorities: u32 = 25;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const NestingBudget: u32 = 20;
+    pub const NestingBudget: u32 = 200;
 }
 
 impl pallet_rmrk_core::Config for Runtime {

--- a/runtime/rhala/src/migrations.rs
+++ b/runtime/rhala/src/migrations.rs
@@ -2,6 +2,13 @@
 use super::*;
 #[allow(unused_imports)]
 use frame_support::traits::OnRuntimeUpgrade;
+pub struct PhalaWorldRhalaMigrations;
+
+impl OnRuntimeUpgrade for PhalaWorldRhalaMigrations {
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        pallet_phala_world::migration::phala_world_migration_rhala::migrate::<Runtime>()
+    }
+}
 
 // Note to "late-migration":
 //

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -874,7 +874,7 @@ parameter_types! {
     pub const ResourceSymbolLimit: u32 = 10;
     pub const MaxPriorities: u32 = 25;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const NestingBudget: u32 = 20;
+    pub const NestingBudget: u32 = 200;
 }
 
 impl pallet_rmrk_core::Config for Runtime {


### PR DESCRIPTION
## Description
Implement migration for the changes from upstream RMRK pallet to move `CollectionIndex` that was purged from the `RmrkCore` pallet and place it in the `PhalaWorld` pallet as `NextCollectionId` in `pallet_pw_nft_sale`. Next, change would be updating all `Nfts` values to be updated based on the change to the `equipped` field in `NftInfo` from `bool` to `Option<(ResourceId, PartId)>`.

## Targets
- [x] Implement migration for `CollectionIndex` to `NextCollectionId` in `PhalaWorld` pallet.
- [x] Implement migration for `NftInfo` type update for field `equipped`
- [ ] Test to ensure migration is successful
- [x] ***MUST FIX NESTING BUDGET BUG IN RMRK ASAP*** https://github.com/Phala-Network/rmrk-substrate/pull/23