### PR TITLE
No check for migration mint_into

### DIFF
--- a/pallets/phala/src/compute/stake_pool_v2.rs
+++ b/pallets/phala/src/compute/stake_pool_v2.rs
@@ -875,11 +875,10 @@ pub mod pallet {
 					let computing_stake =
 						computation::Stakes::<T>::get(&session).unwrap_or_default();
 					if computing_stake != Zero::zero() {
-						wrapped_balances::Pallet::<T>::mint_into(
+						let _ = wrapped_balances::Pallet::<T>::mint_into(
 							&new_pool_info.lock_account,
 							computing_stake,
-						)
-						.expect("mint into should be success");
+						);
 					}
 				});
 				pool_info
@@ -914,10 +913,10 @@ pub mod pallet {
 						pool_info.owner_reward,
 					);
 				};
-				wrapped_balances::Pallet::<T>::mint_into(
+				let _ = wrapped_balances::Pallet::<T>::mint_into(
 					&new_pool_info.basepool.pool_account_id,
 					pool_info.free_stake,
-				).expect("mint should never fail");
+				);
 				base_pool::pallet::Pools::<T>::insert(pid, PoolProxy::StakePool(new_pool_info));
 				base_pool::pallet::PoolCollections::<T>::insert(collection_id, pid);
 				i += 1;
@@ -960,10 +959,10 @@ pub mod pallet {
 						ensure_stake_pool::<T>(pid).expect("stakepool should exist; qed.");
 					// If the balance is too low to mint, we can just drop it.
 					// Even if user_reward is a dust, we should still create user's shares
-					wrapped_balances::Pallet::<T>::mint_into(
+					let _ = wrapped_balances::Pallet::<T>::mint_into(
 						&pool_info.basepool.pool_account_id,
 						user_reward,
-					).expect("mint should never fail");
+					);
 					pool_info.basepool.total_value += user_reward;
 					let mut actual_shares = staker_info.shares;
 					for v in &pool_info.basepool.withdraw_queue {

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -368,6 +368,44 @@ impl Contains<RuntimeCall> for BaseCallFilter {
             };
         }
 
+        // For spv2 migration
+        /*if let RuntimeCall::PhalaRegistry(phala_registry_method) = call {
+            return match phala_registry_method {
+                pallet_registry::Call::migrate_workers { .. }
+                | pallet_registry::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+
+        if let RuntimeCall::PhalaComputation(phala_computation_method) = call {
+            return match phala_computation_method {
+                pallet_computation::Call::migrate_miners { .. }
+                | pallet_computation::Call::migrate_miner_bindings { .. }
+                | pallet_computation::Call::migrate_worker_bindings { .. }
+                | pallet_computation::Call::migrate_stakes { .. }
+                | pallet_computation::Call::migrate_storage_values { .. }
+                | pallet_computation::Call::set_heartbeat_paused { .. }
+                | pallet_computation::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+
+        if let RuntimeCall::PhalaStakePoolv2(phala_stakepoolv2_method) = call {
+            return match phala_stakepoolv2_method {
+                pallet_stakepoolv2::Call::migrate_stakepools { .. }
+                | pallet_stakepoolv2::Call::migrate_pool_stakers { .. }
+                | pallet_stakepoolv2::Call::migrate_stake_ledger { .. }
+                | pallet_stakepoolv2::Call::drain_stakepool_storages { .. }
+                | pallet_stakepoolv2::Call::migrate_worker_assignments { .. }
+                | pallet_stakepoolv2::Call::migrate_subaccount_preimage { .. }
+                | pallet_stakepoolv2::Call::migrate_contribution_whitelist { .. }
+                | pallet_stakepoolv2::Call::migrate_pool_description { .. }
+                | pallet_stakepoolv2::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }*/
+
+
         matches!(
             call,
             RuntimeCall::Sudo { .. } |
@@ -388,7 +426,7 @@ impl Contains<RuntimeCall> for BaseCallFilter {
             RuntimeCall::DmpQueue { .. } |
             // Governance
             RuntimeCall::Identity { .. } | RuntimeCall::Treasury { .. } |
-            RuntimeCall::Democracy { .. } | RuntimeCall::PhragmenElection { .. } |
+            RuntimeCall::Democracy { .. } | /*RuntimeCall::PhragmenElection { .. } |*/
             RuntimeCall::Council { .. } | RuntimeCall::TechnicalCommittee { .. } | RuntimeCall::TechnicalMembership { .. } |
             RuntimeCall::Bounties { .. } | RuntimeCall::ChildBounties { .. } |
             RuntimeCall::Lottery { .. } | RuntimeCall::Tips { .. } |
@@ -894,7 +932,7 @@ parameter_types! {
     pub const ResourceSymbolLimit: u32 = 10;
     pub const MaxPriorities: u32 = 25;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const NestingBudget: u32 = 20;
+    pub const NestingBudget: u32 = 200;
 }
 
 impl pallet_rmrk_core::Config for Runtime {

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("khala"),
     impl_name: create_runtime_str!("khala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1197,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -882,7 +882,7 @@ parameter_types! {
     pub const ResourceSymbolLimit: u32 = 10;
     pub const MaxPriorities: u32 = 25;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const NestingBudget: u32 = 20;
+    pub const NestingBudget: u32 = 200;
 }
 
 impl pallet_rmrk_core::Config for Runtime {

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -884,7 +884,7 @@ parameter_types! {
     pub const ResourceSymbolLimit: u32 = 10;
     pub const MaxPriorities: u32 = 25;
     pub const MaxResourcesOnMint: u32 = 100;
-    pub const NestingBudget: u32 = 20;
+    pub const NestingBudget: u32 = 200;
 }
 
 impl pallet_rmrk_core::Config for Runtime {


### PR DESCRIPTION
we shouldn't check mint_into.'s result, for there are some dust in old storage and can't mint such a small amount, we can just ignore it.