### PR TITLE
Releasing v0.1.19-9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "khala-node"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 dependencies = [
  "async-trait",
  "clap",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "khala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -6754,7 +6754,7 @@ dependencies = [
 
 [[package]]
 name = "phala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "rhala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -11752,7 +11752,7 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "thala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-node"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 license = "Apache-2.0"
 homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/khala-parachain"

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("khala"),
     impl_name: create_runtime_str!("khala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1199,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -369,6 +369,41 @@ impl Contains<RuntimeCall> for BaseCallFilter {
             };
         }
 
+        // For spv2 migration
+        if let RuntimeCall::PhalaRegistry(phala_registry_method) = call {
+            return match phala_registry_method {
+                pallet_registry::Call::migrate_workers { .. }
+                | pallet_registry::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+        if let RuntimeCall::PhalaComputation(phala_computation_method) = call {
+            return match phala_computation_method {
+                pallet_computation::Call::migrate_miners { .. }
+                | pallet_computation::Call::migrate_miner_bindings { .. }
+                | pallet_computation::Call::migrate_worker_bindings { .. }
+                | pallet_computation::Call::migrate_stakes { .. }
+                | pallet_computation::Call::migrate_storage_values { .. }
+                | pallet_computation::Call::set_heartbeat_paused { .. }
+                | pallet_computation::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+        if let RuntimeCall::PhalaStakePoolv2(phala_stake_pool_v2_method) = call {
+            return match phala_stake_pool_v2_method {
+                pallet_stake_pool_v2::Call::migrate_stakepools { .. }
+                | pallet_stake_pool_v2::Call::migrate_pool_stakers { .. }
+                | pallet_stake_pool_v2::Call::migrate_stake_ledger { .. }
+                | pallet_stake_pool_v2::Call::drain_stakepool_storages { .. }
+                | pallet_stake_pool_v2::Call::migrate_worker_assignments { .. }
+                | pallet_stake_pool_v2::Call::migrate_subaccount_preimage { .. }
+                | pallet_stake_pool_v2::Call::migrate_contribution_whitelist { .. }
+                | pallet_stake_pool_v2::Call::migrate_pool_description { .. }
+                | pallet_stake_pool_v2::Call::__Ignore { .. } => true,
+                _ => false,
+            };
+        }
+
         matches!(
             call,
             // System
@@ -388,15 +423,15 @@ impl Contains<RuntimeCall> for BaseCallFilter {
             RuntimeCall::DmpQueue { .. } |
             // Governance
             RuntimeCall::Identity { .. } | RuntimeCall::Treasury { .. } |
-            RuntimeCall::Democracy { .. } | //RuntimeCall::PhragmenElection { .. } |
+            RuntimeCall::Democracy { .. } | // RuntimeCall::PhragmenElection { .. } |
             RuntimeCall::Council { .. } | RuntimeCall::TechnicalCommittee { .. } | RuntimeCall::TechnicalMembership { .. } |
             RuntimeCall::Bounties { .. } | RuntimeCall::ChildBounties { .. } |
             RuntimeCall::Lottery { .. } | RuntimeCall::Tips { .. } |
             // Phala
-            RuntimeCall::PhalaMq { .. } | RuntimeCall::PhalaRegistry { .. } |
-            RuntimeCall::PhalaComputation { .. } |
-            RuntimeCall::PhalaStakePoolv2 { .. } | RuntimeCall::PhalaBasePool { .. } |
-            RuntimeCall::PhalaWrappedBalances { .. } | RuntimeCall::PhalaVault { .. } |
+            RuntimeCall::PhalaMq { .. } | // RuntimeCall::PhalaRegistry { .. } |
+            // RuntimeCall::PhalaComputation { .. } |
+            // RuntimeCall::PhalaStakePoolv2 { .. } | RuntimeCall::PhalaBasePool { .. } |
+            // RuntimeCall::PhalaWrappedBalances { .. } | RuntimeCall::PhalaVault { .. } |
             // RuntimeCall::PhalaFatContracts { .. } | RuntimeCall::PhalaFatTokenomic { .. } |
             // Phala World
             RuntimeCall::PWNftSale { .. } | RuntimeCall::PWIncubation { .. }

--- a/runtime/phala/Cargo.toml
+++ b/runtime/phala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("phala"),
     impl_name: create_runtime_str!("phala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1199,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 5,

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("rhala"),
     impl_name: create_runtime_str!("rhala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1199,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.19-9"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("thala"),
     impl_name: create_runtime_str!("thala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1199,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,


### PR DESCRIPTION
This version is for migrating StakePool v1 to v2,

It will disable most of all Phala pallets functionalities, so computing (mining) will not work