### PR TITLE
Bump to v0.1.20, spec version 1200 (Khala 1201)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "khala-node"
-version = "0.1.20-dev"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "clap",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "khala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -6754,7 +6754,7 @@ dependencies = [
 
 [[package]]
 name = "phala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "rhala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",
@@ -11750,7 +11750,7 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "thala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 dependencies = [
  "assets-registry",
  "cumulus-pallet-aura-ext",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-node"
-version = "0.1.20-dev"
+version = "0.1.20"
 license = "Apache-2.0"
 homepage = "https://phala.network/"
 repository = "https://github.com/Phala-Network/khala-parachain"

--- a/runtime/khala/Cargo.toml
+++ b/runtime/khala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "khala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/phala/Cargo.toml
+++ b/runtime/phala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("phala"),
     impl_name: create_runtime_str!("phala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1200,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 5,

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -161,7 +161,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("rhala"),
     impl_name: create_runtime_str!("rhala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1200,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/runtime/thala/Cargo.toml
+++ b/runtime/thala/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "thala-parachain-runtime"
-version = "0.1.20-dev"
+version = "0.1.20"
 authors = ["Phala Network"]
 edition = "2021"
 

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("thala"),
     impl_name: create_runtime_str!("thala"),
     authoring_version: 1,
-    spec_version: 1196,
+    spec_version: 1200,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,


### PR DESCRIPTION
- No filter for Phala pallets (means all Phala pallet functions will work again)
- Corrected wPHA asset id
- Fix an upstream critical client bug (node will random crash hourly)
- Bump all spec version to 1200, Khala is 1201