### PR TITLE
Optimization of storage usage in Stakepool v2

### DIFF
--- a/pallets/phala/src/compute/base_pool.rs
+++ b/pallets/phala/src/compute/base_pool.rs
@@ -96,14 +96,6 @@ pub mod pallet {
 		NftId,
 	);
 
-	type ShareTransferProxy<T> = (
-		<T as frame_system::Config>::AccountId,
-		<T as frame_system::Config>::AccountId,
-		u64,
-		BalanceOf<T>,
-		PoolType,
-	);
-
 	#[pallet::storage]
 	pub type LockIterateStartPos<T> = StorageValue<_, Option<LockKey>, ValueQuery>;
 
@@ -378,14 +370,17 @@ pub mod pallet {
 				// The share held by the vault
 				let mut vault = ensure_vault::<T>(*vault_staker)
 					.expect("vault in value_subscribers should always exist: qed.");
-				let nft_id = Pallet::<T>::merge_or_init_nft_for_staker(
+				let maybe_nft_id = Pallet::<T>::merge_nft_for_staker(
 					self.cid,
 					vault.basepool.pool_account_id.clone(),
 					self.pid,
-					PoolType::StakePool,
 				)
 				.expect("merge nft shoule always success: qed.");
 
+				let Some(nft_id) = maybe_nft_id else {
+					// Never get here
+					continue;
+				};
 				let nft_guard = Pallet::<T>::get_nft_attr_guard(self.cid, nft_id)
 					.expect("get nft attr should always success: qed.");
 				let mut vault_shares = nft_guard.attr.shares.to_fixed();
@@ -439,6 +434,7 @@ pub mod pallet {
 		/// The caller must be the owner of the pool.
 		/// If a pool hasn't registed in the wihtelist map, any staker could contribute as what they use to do.
 		/// The whitelist has a lmit len of 100 stakers.
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn add_staker_to_whitelist(
 			origin: OriginFor<T>,
@@ -477,6 +473,7 @@ pub mod pallet {
 		/// Adds a description to the pool
 		///
 		/// The caller must be the owner of the pool.
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn set_pool_description(
 			origin: OriginFor<T>,
@@ -496,6 +493,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
 		pub fn reset_lock_iter_pos(origin: OriginFor<T>) -> DispatchResult {
@@ -505,6 +503,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(0)]
 		pub fn remove_unused_lock(origin: OriginFor<T>, max_iterations: u32) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -546,6 +545,7 @@ pub mod pallet {
 		///
 		/// The caller must be the owner of the pool.
 		/// If the last staker in the whitelist is removed, the pool will return back to a normal pool that allow anyone to contribute.
+		#[pallet::call_index(4)]
 		#[pallet::weight(0)]
 		pub fn remove_staker_from_whitelist(
 			origin: OriginFor<T>,
@@ -582,74 +582,6 @@ pub mod pallet {
 				});
 			}
 
-			Ok(())
-		}
-
-		#[pallet::weight(0)]
-		#[frame_support::transactional]
-		pub fn backfill_transfer_shares(
-			origin: OriginFor<T>,
-			input: Vec<ShareTransferProxy<T>>,
-		) -> DispatchResult {
-			let who = ensure_signed(origin)?;
-			Self::ensure_migration_root(who)?;
-
-			for item in input.iter() {
-				let (from, dest, pid, shares, pool_type) = item;
-				let base_pool_info = match &pool_type {
-					PoolType::StakePool => {
-						let stake_pool = ensure_stake_pool::<T>(*pid)?;
-						stake_pool.basepool
-					}
-					PoolType::Vault => {
-						let vault = ensure_vault::<T>(*pid)?;
-						vault.basepool
-					}
-				};
-				let from_nft_id = Self::merge_or_init_nft_for_staker(
-					base_pool_info.cid,
-					from.clone(),
-					base_pool_info.pid,
-					pool_type.clone(),
-				)?;
-				let from_nft_guard = Self::get_nft_attr_guard(base_pool_info.cid, from_nft_id)
-					.expect("get nftattr should always success; qed.");
-				let dest_nft_id = Self::merge_or_init_nft_for_staker(
-					base_pool_info.cid,
-					dest.clone(),
-					base_pool_info.pid,
-					pool_type.clone(),
-				)?;
-				let dest_nft_guard = Self::get_nft_attr_guard(base_pool_info.cid, dest_nft_id)
-					.expect("get nftattr should always success; qed.");
-
-				ensure!(
-					from_nft_guard.attr.shares >= *shares,
-					Error::<T>::TransferSharesAmountInvalid
-				);
-				let from_shares = from_nft_guard.attr.shares - *shares;
-				let dest_shares = dest_nft_guard.attr.shares + *shares;
-				from_nft_guard.unlock();
-				dest_nft_guard.unlock();
-				Self::burn_nft(from, base_pool_info.cid, from_nft_id)?;
-				let _ = Self::mint_nft(
-					base_pool_info.cid,
-					from.clone(),
-					from_shares,
-					*pid,
-					pool_type.clone(),
-				)
-				.expect("mint nft should success; qed.");
-				Self::burn_nft(dest, base_pool_info.cid, dest_nft_id)?;
-				let _ = Self::mint_nft(
-					base_pool_info.cid,
-					dest.clone(),
-					dest_shares,
-					*pid,
-					pool_type.clone(),
-				)
-				.expect("mint nft should success; qed.");
-			}
 			Ok(())
 		}
 	}
@@ -692,7 +624,6 @@ pub mod pallet {
 			pool: &mut BasePool<T::AccountId, BalanceOf<T>>,
 			account_id: T::AccountId,
 			amount: BalanceOf<T>,
-			pool_type: PoolType,
 		) -> Result<BalanceOf<T>, DispatchError> {
 			ensure!(
 				// There's no share, meaning the pool is empty;
@@ -708,16 +639,15 @@ pub mod pallet {
 					Error::<T>::NotInContributeWhitelist
 				);
 			}
-			Self::merge_or_init_nft_for_staker(
+			Self::merge_nft_for_staker(
 				pool.cid,
 				account_id.clone(),
 				pool.pid,
-				pool_type.clone(),
 			)?;
 			// The nft instance must be wrote to Nft storage at the end of the function
 			// this nft's property shouldn't be accessed or wrote again from storage before set_nft_attr
 			// is called. Or the property of the nft will be overwrote incorrectly.
-			let shares = Self::add_stake_to_new_nft(pool, account_id, amount, pool_type);
+			let shares = Self::add_stake_to_new_nft(pool, account_id, amount);
 			Ok(shares)
 		}
 
@@ -733,7 +663,6 @@ pub mod pallet {
 			nft: &mut NftAttr<BalanceOf<T>>,
 			account_id: T::AccountId,
 			shares: BalanceOf<T>,
-			pool_type: PoolType,
 		) -> DispatchResult {
 			if pool.share_price().is_none() {
 				nft.shares = nft
@@ -761,7 +690,7 @@ pub mod pallet {
 					.expect("burn nft attr should always success; qed.");
 			}
 
-			let split_nft_id = Self::mint_nft(pool.cid, pallet_id(), shares, pool.pid, pool_type)
+			let split_nft_id = Self::mint_nft(pool.cid, pallet_id(), shares, pool.pid)
 				.expect("mint nft should always success");
 			nft.shares = nft
 				.shares
@@ -846,13 +775,12 @@ pub mod pallet {
 			pool: &mut BasePool<T::AccountId, BalanceOf<T>>,
 			account_id: T::AccountId,
 			amount: BalanceOf<T>,
-			pool_type: PoolType,
 		) -> BalanceOf<T> {
 			let shares = match pool.share_price() {
 				Some(price) if price != fp!(0) => bdiv(amount, &price),
 				_ => amount, // adding new stake (share price = 1)
 			};
-			Self::mint_nft(pool.cid, account_id.clone(), shares, pool.pid, pool_type)
+			Self::mint_nft(pool.cid, account_id.clone(), shares, pool.pid)
 				.expect("mint should always success; qed.");
 			pool.total_shares += shares;
 			pool.total_value += amount;
@@ -915,7 +843,6 @@ pub mod pallet {
 			contributer: T::AccountId,
 			shares: BalanceOf<T>,
 			pid: u64,
-			pool_type: PoolType,
 		) -> Result<NftId, DispatchError> {
 			pallet_rmrk_core::Collections::<T>::get(cid)
 				.ok_or(pallet_rmrk_core::Error::<T>::CollectionUnknown)?;
@@ -935,7 +862,7 @@ pub mod pallet {
 
 			let attr = NftAttr { shares };
 			Self::set_nft_attr(cid, nft_id, &attr)?;
-			Self::set_nft_desc_attr(cid, pid, nft_id, pool_type)?;
+			Self::set_nft_desc_attr(cid, nft_id)?;
 			pallet_rmrk_core::Pallet::<T>::set_lock((cid, nft_id), true);
 			Self::deposit_event(Event::<T>::NftCreated {
 				pid,
@@ -967,30 +894,6 @@ pub mod pallet {
 		}
 
 		fn remove_properties(cid: CollectionId, nft_id: NftId) {
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "name"
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let _ = pallet_rmrk_core::Pallet::<T>::do_remove_property(cid, Some(nft_id), key);
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = NFT_PROPERTY_KEY
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let _ = pallet_rmrk_core::Pallet::<T>::do_remove_property(cid, Some(nft_id), key);
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "description"
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let _ = pallet_rmrk_core::Pallet::<T>::do_remove_property(cid, Some(nft_id), key);
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "image"
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let _ = pallet_rmrk_core::Pallet::<T>::do_remove_property(cid, Some(nft_id), key);
 			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "createtime"
 				.as_bytes()
 				.to_vec()
@@ -1000,24 +903,28 @@ pub mod pallet {
 		}
 
 		/// Merges multiple nfts belong to one user in the pool.
-		///
-		/// TODO(mingxuan): should try to avoid 0 share nft mint.
-		pub fn merge_or_init_nft_for_staker(
+		pub fn merge_nft_for_staker(
 			cid: CollectionId,
 			staker: T::AccountId,
 			pid: u64,
-			pool_type: PoolType,
-		) -> Result<NftId, DispatchError> {
+		) -> Result<Option<NftId>, DispatchError> {
 			let mut total_shares: BalanceOf<T> = Zero::zero();
-			pallet_uniques::Pallet::<T>::owned_in_collection(&cid, &staker).for_each(|nftid| {
+			let nfts: Vec<_> = pallet_uniques::Pallet::<T>::owned_in_collection(&cid, &staker).collect();
+			match nfts.len() {
+			  0 => return Ok(None),
+			  1 => return Ok(Some(nfts[0])),
+			  _ => (),
+			};
+			for nftid in nfts {
 				let nft_guard =
 					Self::get_nft_attr_guard(cid, nftid).expect("get nft should not fail: qed.");
 				let property = nft_guard.attr.clone();
 				nft_guard.unlock();
 				total_shares += property.shares;
 				Self::burn_nft(&staker, cid, nftid).expect("burn nft should not fail: qed.");
-			});
-			Self::mint_nft(cid, staker, total_shares, pid, pool_type)
+			}
+			let nft_id = Self::mint_nft(cid, staker, total_shares, pid)?;
+			Ok(Some(nft_id))
 		}
 
 		/// Gets nft attr, can only be called in the pallet
@@ -1047,60 +954,9 @@ pub mod pallet {
 
 		fn set_nft_desc_attr(
 			cid: CollectionId,
-			pid: u64,
 			nft_id: NftId,
-			pool_type: PoolType,
 		) -> DispatchResult {
 			pallet_rmrk_core::Pallet::<T>::set_lock((cid, nft_id), false);
-			// TODO(mingxuan): make a common function to simplify code.
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "name"
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let pool_type_str = match pool_type {
-				PoolType::Vault => "Vault",
-				PoolType::StakePool => "Stakepool",
-			};
-			let value: BoundedVec<u8, <T as pallet_uniques::Config>::ValueLimit> = format!(
-				"Khala - {} Delegation NFT - #{pid} - {nft_id}",
-				&pool_type_str
-			)
-			.as_bytes()
-			.to_vec()
-			.try_into()
-			.expect("create a bvec from string should never fail; qed.");
-			pallet_rmrk_core::Pallet::<T>::do_set_property(cid, Some(nft_id), key, value)?;
-
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "description"
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let value: BoundedVec<u8, <T as pallet_uniques::Config>::ValueLimit> =
-				format!("Khala - {} - #{pid}", &pool_type_str)
-					.as_bytes()
-					.to_vec()
-					.try_into()
-					.expect("create a bvec from string should never fail; qed.");
-			pallet_rmrk_core::Pallet::<T>::do_set_property(cid, Some(nft_id), key, value)?;
-
-			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "image"
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("str coverts to bvec should never fail; qed.");
-			let image_str = match pool_type {
-				PoolType::Vault => "ar://2K3Pq9XKTw4LjTyyIbsrC53bkOB7NiDxdIcH0aILM-Y",
-				PoolType::StakePool => "ar://C9yMARqdiPXu8IixnwU6J_jMEkN2lTPG4kNouSQ57uI",
-			};
-			let value: BoundedVec<u8, <T as pallet_uniques::Config>::ValueLimit> = image_str
-				.as_bytes()
-				.to_vec()
-				.try_into()
-				.expect("create a bvec from string should never fail; qed.");
-			pallet_rmrk_core::Pallet::<T>::do_set_property(cid, Some(nft_id), key, value)?;
-
 			let key: BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit> = "createtime"
 				.as_bytes()
 				.to_vec()
@@ -1156,9 +1012,8 @@ pub mod pallet {
 			shares: BalanceOf<T>,
 			nft_id: NftId,
 			as_vault: Option<u64>,
-			pool_type: PoolType,
 		) -> DispatchResult {
-			Self::push_withdraw_in_queue(pool_info, nft, userid.clone(), shares, pool_type)?;
+			Self::push_withdraw_in_queue(pool_info, nft, userid.clone(), shares)?;
 			Self::deposit_event(Event::<T>::WithdrawalQueued {
 				pid: pool_info.pid,
 				user: userid,

--- a/pallets/phala/src/compute/computation.rs
+++ b/pallets/phala/src/compute/computation.rs
@@ -430,6 +430,7 @@ pub mod pallet {
 		/// Sets the cool down expiration time in seconds.
 		///
 		/// Can only be called by root.
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		pub fn set_cool_down_expiration(origin: OriginFor<T>, period: u64) -> DispatchResult {
 			ensure_root(origin)?;
@@ -443,6 +444,7 @@ pub mod pallet {
 		///
 		/// It will trigger a force stop of computing if the worker is still in computing state. Anyone
 		/// can call it.
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		pub fn unbind(origin: OriginFor<T>, session: T::AccountId) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -458,6 +460,7 @@ pub mod pallet {
 		/// Triggers a force heartbeat request to all workers by sending a MAX pow target
 		///
 		/// Only for integration test.
+		#[pallet::call_index(2)]
 		#[pallet::weight(1)]
 		pub fn force_heartbeat(origin: OriginFor<T>) -> DispatchResult {
 			ensure_root(origin)?;
@@ -471,6 +474,7 @@ pub mod pallet {
 		/// Start computing
 		///
 		/// Only for integration test.
+		#[pallet::call_index(3)]
 		#[pallet::weight(1)]
 		pub fn force_start_computing(
 			origin: OriginFor<T>,
@@ -485,6 +489,7 @@ pub mod pallet {
 		/// Stop computing
 		///
 		/// Only for integration test.
+		#[pallet::call_index(4)]
 		#[pallet::weight(1)]
 		pub fn force_stop_computing(origin: OriginFor<T>, session: T::AccountId) -> DispatchResult {
 			ensure_root(origin)?;
@@ -495,6 +500,7 @@ pub mod pallet {
 		/// Updates the tokenomic parameters at the end of this block.
 		///
 		/// Can only be called by the tokenomic admin.
+		#[pallet::call_index(5)]
 		#[pallet::weight(1)]
 		pub fn update_tokenomic(
 			origin: OriginFor<T>,
@@ -512,6 +518,7 @@ pub mod pallet {
 		/// but never be paid out until the heartbeat is resumed.
 		///
 		/// Can only be called by root.
+		#[pallet::call_index(6)]
 		#[pallet::weight(1)]
 		pub fn set_heartbeat_paused(origin: OriginFor<T>, paused: bool) -> DispatchResult {
 			T::GovernanceOrigin::ensure_origin(origin)?;

--- a/pallets/phala/src/compute/wrapped_balances.rs
+++ b/pallets/phala/src/compute/wrapped_balances.rs
@@ -5,7 +5,7 @@ pub mod pallet {
 	use crate::balance_convert::{mul as bmul, FixedPointConvert};
 	use crate::base_pool;
 	use crate::computation;
-	use crate::pool_proxy::{PoolProxy, PoolType};
+	use crate::pool_proxy::PoolProxy;
 	use crate::registry;
 	use crate::vault;
 	use crate::{BalanceOf, NegativeImbalanceOf, PhalaConfig};
@@ -178,17 +178,10 @@ pub mod pallet {
 			_nft_id: &NftId,
 		) -> bool {
 			if let Some(pid) = base_pool::pallet::PoolCollections::<T>::get(collection_id) {
-				let pool_proxy = base_pool::Pallet::<T>::pool_collection(pid)
-					.expect("already checked exist; qed.");
-				let pool_type = match pool_proxy {
-					PoolProxy::Vault(_res) => PoolType::Vault,
-					PoolProxy::StakePool(_res) => PoolType::StakePool,
-				};
-				base_pool::Pallet::<T>::merge_or_init_nft_for_staker(
+				base_pool::Pallet::<T>::merge_nft_for_staker(
 					*collection_id,
 					recipient.clone(),
 					pid,
-					pool_type,
 				)
 				.expect("mrege or init should not fail");
 			}
@@ -208,6 +201,7 @@ pub mod pallet {
 		/// Wraps some pha and gain equal amount of W-PHA
 		///
 		/// The wrapped pha is stored in `WrappedBalancesAccountId`'s wallet and can not be taken away
+		#[pallet::call_index(0)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
 		pub fn wrap(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
@@ -233,6 +227,7 @@ pub mod pallet {
 		/// Burns the amount of all free W-PHA and unwraps equal amount of pha
 		///
 		/// The unwrapped pha is transfered from `WrappedBalancesAccountId` to the user's wallet
+		#[pallet::call_index(1)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
 		pub fn unwrap_all(origin: OriginFor<T>) -> DispatchResult {
@@ -257,6 +252,7 @@ pub mod pallet {
 		/// Unwraps some pha by burning equal amount of W-PHA
 		///
 		/// The unwrapped pha is transfered from `WrappedBalancesAccountId` to the user's wallet
+		#[pallet::call_index(2)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
 		pub fn unwrap(origin: OriginFor<T>, amount: BalanceOf<T>) -> DispatchResult {
@@ -290,6 +286,7 @@ pub mod pallet {
 		///
 		/// Can both approve and oppose a vote at the same time
 		/// The W-PHA used in vote will be locked until the vote is finished or canceled
+		#[pallet::call_index(3)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
 		pub fn vote(
@@ -325,6 +322,7 @@ pub mod pallet {
 		/// Tries to unlock W-PHAs used in vote after the vote finished or canceled
 		///
 		/// Must assign the max iterations to avoid computing complexity overwhelm
+		#[pallet::call_index(4)]
 		#[pallet::weight(0)]
 		#[frame_support::transactional]
 		pub fn unlock(

--- a/pallets/phala/src/test.rs
+++ b/pallets/phala/src/test.rs
@@ -281,14 +281,12 @@ fn test_mint_nft() {
 			1,
 			1000 * DOLLARS,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		assert_ok!(PhalaBasePool::mint_nft(
 			pool_info.basepool.cid,
 			2,
 			500 * DOLLARS,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		{
 			assert_ok!(PhalaBasePool::get_nft_attr_guard(pool_info.basepool.cid, 0));
@@ -311,7 +309,7 @@ fn test_mint_nft() {
 }
 
 #[test]
-fn test_merge_or_init_nft() {
+fn test_merge_nft() {
 	new_test_ext().execute_with(|| {
 		set_block_1();
 		setup_workers(2);
@@ -322,22 +320,19 @@ fn test_merge_or_init_nft() {
 			1,
 			1000 * DOLLARS,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		assert_ok!(PhalaBasePool::mint_nft(
 			pool_info.basepool.cid,
 			1,
 			2000 * DOLLARS,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		let nftid_arr = pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000);
 		assert_eq!(nftid_arr.count(), 2);
-		assert_ok!(PhalaBasePool::merge_or_init_nft_for_staker(
+		assert_ok!(PhalaBasePool::merge_nft_for_staker(
 			pool_info.basepool.cid,
 			1,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		let nftid_arr: Vec<NftId> =
 			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000).collect();
@@ -349,11 +344,10 @@ fn test_merge_or_init_nft() {
 				.clone();
 			assert_eq!(nft_attr.shares, 3000 * DOLLARS);
 		}
-		assert_ok!(PhalaBasePool::merge_or_init_nft_for_staker(
+		assert_ok!(PhalaBasePool::merge_nft_for_staker(
 			pool_info.basepool.cid,
 			2,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		let mut nftid_arr: Vec<NftId> =
 			pallet_rmrk_core::Nfts::<Test>::iter_key_prefix(10000).collect();
@@ -361,14 +355,7 @@ fn test_merge_or_init_nft() {
 			let nft = pallet_rmrk_core::Nfts::<Test>::get(10000, x).unwrap();
 			nft.owner == rmrk_traits::AccountIdOrCollectionNftTuple::AccountId(2)
 		});
-		assert_eq!(nftid_arr.len(), 1);
-		{
-			let nft_attr = PhalaBasePool::get_nft_attr_guard(pool_info.basepool.cid, nftid_arr[0])
-				.unwrap()
-				.attr
-				.clone();
-			assert_eq!(nft_attr.shares, 0);
-		}
+		assert_eq!(nftid_arr.len(), 0);
 	});
 }
 
@@ -384,7 +371,6 @@ fn test_set_nft_attr() {
 			1,
 			1000 * DOLLARS,
 			pool_info.basepool.pid,
-			PoolType::StakePool,
 		));
 		{
 			let mut nft_attr_guard =

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("khala"),
     impl_name: create_runtime_str!("khala"),
     authoring_version: 1,
-    spec_version: 1207,
+    spec_version: 1208,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("phala"),
     impl_name: create_runtime_str!("phala"),
     authoring_version: 1,
-    spec_version: 1200,
+    spec_version: 1208,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 5,

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -164,7 +164,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("rhala"),
     impl_name: create_runtime_str!("rhala"),
     authoring_version: 1,
-    spec_version: 1207,
+    spec_version: 1208,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("thala"),
     impl_name: create_runtime_str!("thala"),
     authoring_version: 1,
-    spec_version: 1207,
+    spec_version: 1208,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 6,


### PR DESCRIPTION
**Background**
Current stake pool v2 introduced a lot of mint_nft and burn_nft when merging a user's nfts in a collection, many of them are unnecessary and it leads to storage being overwhelmed on the runtime.
And some of the unused codes are removed in this pr by the way.
**Solutions**
1. Changing the function merge_nfts_for_stakers by reducing burn and mint in unnecessary cases
2. The frontend will show nfts basic information generated on their own instead of using nft-properties in on-chain storages So that we can no longer write these data on-chain.