### PR TITLE
Enable xcm sending in shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10978,6 +10978,7 @@ dependencies = [
  "frame-try-runtime",
  "log",
  "pallet-sudo",
+ "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
  "scale-info",

--- a/node/src/chain_spec/shell.rs
+++ b/node/src/chain_spec/shell.rs
@@ -90,5 +90,8 @@ fn genesis(
         parachain_info: shell_parachain_runtime::ParachainInfoConfig { parachain_id },
         parachain_system: Default::default(),
         sudo: shell_parachain_runtime::SudoConfig { key: Some(root_key) },
+        polkadot_xcm: shell_parachain_runtime::PolkadotXcmConfig {
+            safe_xcm_version: Some(2),
+        },
     }
 }

--- a/runtime/shell/Cargo.toml
+++ b/runtime/shell/Cargo.toml
@@ -41,6 +41,7 @@ parachain-info = { git = "https://github.com/paritytech/cumulus", branch = "polk
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
 
 # Pallets
 
@@ -80,7 +81,8 @@ std = [
 	"xcm/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
-	"pallet-sudo/std"
+	"pallet-sudo/std",
+	"pallet-xcm/std",
 ]
 try-runtime = [
 	"frame-try-runtime",

--- a/runtime/shell/src/lib.rs
+++ b/runtime/shell/src/lib.rs
@@ -151,7 +151,7 @@ impl frame_system::Config for Runtime {
     type OnNewAccount = ();
     type OnKilledAccount = ();
     type DbWeight = ();
-    type BaseCallFilter = frame_support::traits::Everything;
+    type BaseCallFilter = BaseCallFilter;
     type SystemWeightInfo = ();
     type BlockWeights = RuntimeBlockWeights;
     type BlockLength = RuntimeBlockLength;

--- a/runtime/shell/src/xcm_config.rs
+++ b/runtime/shell/src/xcm_config.rs
@@ -62,7 +62,7 @@ parameter_types! {
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
     type RuntimeCall = RuntimeCall;
-    type XcmSender = XcmRouter; // sending XCM not supported
+    type XcmSender = XcmRouter;
     type AssetTransactor = (); // balances not supported
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     type IsReserve = (); // balances not supported


### PR DESCRIPTION
This PR will add `pallet-xcm` from polkadot into shell runtime, to make shell able to send XCM relay chain (only to relay chain).