### PR TITLE
Add staking_list_hook

### DIFF
--- a/pallets/phala-world/src/marketplace.rs
+++ b/pallets/phala-world/src/marketplace.rs
@@ -8,6 +8,7 @@ pub use pallet_rmrk_core::Nfts;
 pub use pallet_rmrk_market;
 
 use crate::nft_sale::BalanceOf;
+pub use crate::traits::MarketPlaceStakingListHook;
 pub use frame_support::pallet_prelude::*;
 pub use frame_system::pallet_prelude::*;
 pub use rmrk_traits::{primitives::*, RoyaltyInfo};
@@ -33,6 +34,7 @@ pub mod pallet {
 	{
 		/// Because this pallet emits events, it depends on the runtime's definition of an event.
 		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type StakingListHook: MarketPlaceStakingListHook<Self::CollectionId, Self::ItemId>;
 	}
 
 	#[pallet::pallet]
@@ -150,8 +152,9 @@ where
 		}
 	}
 
-	fn can_sell_in_marketplace(collection_id: T::CollectionId, _nft_id: T::ItemId) -> bool {
+	fn can_sell_in_marketplace(collection_id: T::CollectionId, nft_id: T::ItemId) -> bool {
 		pallet_pw_incubation::ShellCollectionId::<T>::get() == Some(collection_id)
+			|| T::StakingListHook::can_list(&collection_id, &nft_id)
 	}
 }
 

--- a/pallets/phala-world/src/migration.rs
+++ b/pallets/phala-world/src/migration.rs
@@ -2,7 +2,7 @@ use super::*;
 
 mod phala_world_migration_common {
 	use super::*;
-	use frame_support::{traits::StorageVersion};
+	use frame_support::traits::StorageVersion;
 
 	pub type Versions = (
 		// Version for NFT Sale pallet

--- a/pallets/phala-world/src/traits.rs
+++ b/pallets/phala-world/src/traits.rs
@@ -199,3 +199,13 @@ pub fn property_value<V: Encode, ValueLimit: Get<u32>>(value: &V) -> BoundedVec<
 		.try_into()
 		.expect("assume value can fit into property; qed.")
 }
+
+pub trait MarketPlaceStakingListHook<CollectionId, NftId> {
+	fn can_list(collection_id: &CollectionId, nft_id: &NftId) -> bool;
+}
+
+impl<CollectionId, NftId> MarketPlaceStakingListHook<CollectionId, NftId> for () {
+	fn can_list(_collection_id: &CollectionId, _nft_id: &NftId) -> bool {
+		true
+	}
+}

--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -992,6 +992,7 @@ impl pallet_pw_incubation::Config for Runtime {
 
 impl pallet_pw_marketplace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type StakingListHook = ();
 }
 
 impl pallet_parachain_info::Config for Runtime {}

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -999,6 +999,7 @@ impl pallet_pw_incubation::Config for Runtime {
 
 impl pallet_pw_marketplace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type StakingListHook = ();
 }
 
 impl pallet_parachain_info::Config for Runtime {}

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1004,6 +1004,7 @@ impl pallet_pw_incubation::Config for Runtime {
 
 impl pallet_pw_marketplace::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type StakingListHook = ();
 }
 
 impl pallet_parachain_info::Config for Runtime {}


### PR DESCRIPTION
**Background**
Currently MarketPlace can not list staking Nft for it is not supported by the check function. 
**Solution**
Adding a new trait MarketPlaceStakingListHook in PW, and introducing it in pallet marketplace through pallet-config;
Calling the implement function in list-check:`can_sell_in_marketplace`.
And we can implement the trait in compute pallets and passthrough it to MarketPlace by runtime config.