### PR TITLE
Fix XCM message forward

### DIFF
--- a/pallets/subbridge/src/xcmbridge.rs
+++ b/pallets/subbridge/src/xcmbridge.rs
@@ -375,7 +375,8 @@ pub mod pallet {
 				origin: origin_location.clone(),
 				dest_location,
 				beneficiary,
-				dest_weight: max_weight.unwrap_or(XCMWeight::from_parts(6_000_000_000u64, 0)),
+				dest_weight: max_weight
+					.unwrap_or(XCMWeight::from_parts(6_000_000_000u64, 2_000_000u64)),
 				_marker: PhantomData,
 			};
 			let mut msg = xcm_session.message()?;

--- a/pallets/subbridge/src/xtransfer.rs
+++ b/pallets/subbridge/src/xtransfer.rs
@@ -156,7 +156,7 @@ pub mod pallet {
 				temporary_account.into(),
 				what.clone(),
 				who.clone(),
-				Some(XCMWeight::from_parts(6_000_000_000u64, 0)),
+				Some(XCMWeight::from_parts(6_000_000_000u64, 2_000_000u64)),
 			)?;
 			Self::deposit_event(Event::Forwarded { what, who, memo });
 			// TODO: Should we support forward generic message in the future?


### PR DESCRIPTION
This PR is going to fix a bug in the XCM message forwarder exists in SubBridge.

When forwarding XCM message from other chains like Ethereum, we hardcode the `proofSize` when constructing the XCM message. In XCM V3, this should be a meaningful value rather than 0. Giving 0 will lead to a `Barrier` error on the dest chain. See this [record](https://astar.subscan.io/extrinsic/4041769-1?event=4041769-5).