### PR TITLE
Removing Dwellir bootnode

### DIFF
--- a/node/res/khala.json
+++ b/node/res/khala.json
@@ -7,7 +7,6 @@
     "/dns4/khala-node-eu-1.phala.network/tcp/30333/ws/p2p/12D3KooWGxVpuCw6gNb67ST2LnsqfYhBYPKm75AiVHoSZF7nxTor",
     "/dns4/khala-node-asia-2.phala.network/tcp/30333/ws/p2p/12D3KooWLi5WqKWv3WwKRbW4s7owvKJoMuJ9sCntBpwDzi32vWHd",
     "/dns4/khala-node-asia-1.phala.network/tcp/30333/ws/p2p/12D3KooWNRR7q6TiFJ9zooSQGxL7xtRtikAMijG3VVrN44bNRtCj",
-    "/dns4/khala-boot.dwellir.com/tcp/30339/ws/p2p/12D3KooWT1g1bYkSoBH6c1NhSY8ZnXzs8bpyb8yvDA6JkEF1rEXK",
     "/dns4/node-6824203058247540736-0.p2p.onfinality.io/tcp/19775/ws/p2p/12D3KooWCacYjnoQSwCqrPKvkSueqbtczNDD2nbwrxbZhgb6MRVq",
     "/dns4/node-6824203081408155648-0.p2p.onfinality.io/tcp/22215/ws/p2p/12D3KooWJVCXbjoyyNbPoyWNQDUki7h4qXNm6gzF69ogtWzT296P",
     "/dns4/node-6824202167515451392-0.p2p.onfinality.io/tcp/11557/ws/p2p/12D3KooWCaYBfP61iZfRvDC6BQU4ey2Ya7ioZHK972RehbYkveEB"


### PR DESCRIPTION
This bootnode is not available anymore.