### PR TITLE
change MinEligibleCollators to 0

### DIFF
--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1545,7 +1545,7 @@ impl pallet_session::Config for Runtime {
 parameter_types! {
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub const MaxCollatorCandidates: u32 = 1000;
-    pub const MinEligibleCollators: u32 = 5;
+    pub const MinEligibleCollators: u32 = 0;
     pub const SessionLength: BlockNumber = 6 * HOURS;
     pub const MaxInvulnerables: u32 = 100;
 }

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -1264,7 +1264,7 @@ impl pallet_session::Config for Runtime {
 parameter_types! {
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub const MaxCollatorCandidates: u32 = 1000;
-    pub const MinEligibleCollators: u32 = 5;
+    pub const MinEligibleCollators: u32 = 0;
     pub const SessionLength: BlockNumber = 6 * HOURS;
     pub const MaxInvulnerables: u32 = 100;
 }


### PR DESCRIPTION
All the Phala maintained collators should be Invulnerable. If the MinEligibleCollators larger than 0, the dead third-party collators could not be kicked off because Invulnerable collators do not count as eligible_collators():

https://github.com/paritytech/polkadot-sdk/blob/d2fc1d7c91971e6e630a9db8cb627f8fdc91e8a4/cumulus/pallets/collator-selection/src/lib.rs#L567