### PR TITLE
Change Khala MinCollatorCandidates to 4

### DIFF
--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1546,7 +1546,7 @@ impl pallet_session::Config for Runtime {
 parameter_types! {
     pub const PotId: PalletId = PalletId(*b"PotStake");
     pub const MaxCollatorCandidates: u32 = 1000;
-    pub const MinCollatorCandidates: u32 = 5;
+    pub const MinCollatorCandidates: u32 = 4;
     pub const SessionLength: BlockNumber = 6 * HOURS;
     pub const MaxInvulnerables: u32 = 100;
 }


### PR DESCRIPTION
Currently there are 3 invulnerable collators and 4 regular collators (candidates) maintained by Phala team. There is at least one stale collator from community cannot be kicked since currently we requires 5 minimum candidates. We need to change to 4 to allow this stale collator to be kicked out.

However, Polkadot 1.0 changed the behavior so invulnerable collators will also be calculated against the "MinEligibleCollators". So this change is temporarily for v0.1.25.