### PR TITLE
Add Helikon boot nodes for Khala and Phala

### DIFF
--- a/node/res/khala.json
+++ b/node/res/khala.json
@@ -9,7 +9,9 @@
     "/dns4/khala-node-asia-1.phala.network/tcp/30333/ws/p2p/12D3KooWNRR7q6TiFJ9zooSQGxL7xtRtikAMijG3VVrN44bNRtCj",
     "/dns4/node-6824203058247540736-0.p2p.onfinality.io/tcp/19775/ws/p2p/12D3KooWCacYjnoQSwCqrPKvkSueqbtczNDD2nbwrxbZhgb6MRVq",
     "/dns4/node-6824203081408155648-0.p2p.onfinality.io/tcp/22215/ws/p2p/12D3KooWJVCXbjoyyNbPoyWNQDUki7h4qXNm6gzF69ogtWzT296P",
-    "/dns4/node-6824202167515451392-0.p2p.onfinality.io/tcp/11557/ws/p2p/12D3KooWCaYBfP61iZfRvDC6BQU4ey2Ya7ioZHK972RehbYkveEB"
+    "/dns4/node-6824202167515451392-0.p2p.onfinality.io/tcp/11557/ws/p2p/12D3KooWCaYBfP61iZfRvDC6BQU4ey2Ya7ioZHK972RehbYkveEB",
+    "/dns4/boot.helikon.io/tcp/15220/p2p/12D3KooWCJKmxeCcj3mA12N6P63wi1WaziAYsDacV4zBq3G2nHyZ",
+    "/dns4/boot.helikon.io/tcp/15224/wss/p2p/12D3KooWCJKmxeCcj3mA12N6P63wi1WaziAYsDacV4zBq3G2nHyZ"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
This PR adds the Helikon boot nodes (through p2p and wss/p2p) to the Khala and Phala chain specifications.

To test the Khala boot node:

```
./khala-node --tmp --chain khala --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15220/p2p/12D3KooWCJKmxeCcj3mA12N6P63wi1WaziAYsDacV4zBq3G2nHyZ"
./khala-node --tmp --chain khala --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15224/wss/p2p/12D3KooWCJKmxeCcj3mA12N6P63wi1WaziAYsDacV4zBq3G2nHyZ"
```

To test the Phala boot node:

```
./khala-node --tmp --chain phala --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15020/p2p/12D3KooWDJqyU5YUQNaQzqmfbPbBAKSF4FFwjaQYC5PreQXE4gRE"
./khala-node --tmp --chain phala --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15024/wss/p2p/12D3KooWDJqyU5YUQNaQzqmfbPbBAKSF4FFwjaQYC5PreQXE4gRE"
```

Thanks.