### PR TITLE
Add HashedDescription XCM location converter and remove TinkernetMultisig configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6470,26 +6470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "orml-xcm-builder-kusama"
-version = "1.0.0"
-source = "git+https://github.com/open-web3-stack/orml-xcm-builder?branch=polkadot-v1.2.0#adb45f28914366ec32c9215a26954f567fadf896"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "sp-weights",
- "staging-xcm",
- "staging-xcm-executor",
-]
-
-[[package]]
 name = "p256"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10153,7 +10133,6 @@ dependencies = [
  "hex",
  "hex-literal 0.4.1",
  "log",
- "orml-xcm-builder-kusama",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",

--- a/runtime/rhala/Cargo.toml
+++ b/runtime/rhala/Cargo.toml
@@ -106,9 +106,6 @@ sygma-fee-handler-router = { git = "https://github.com/sygmaprotocol/sygma-subst
 sygma-percentage-feehandler = { git = "https://github.com/sygmaprotocol/sygma-substrate-pallets", branch = "release-polkadot-v1.2.0", default-features = false }
 sygma-runtime-api = { git = "https://github.com/sygmaprotocol/sygma-substrate-pallets", branch = "release-polkadot-v1.2.0", default-features = false }
 
-# ORML Tinkernet Multisig dependencies
-orml-xcm-builder-kusama = { git = "https://github.com/open-web3-stack/orml-xcm-builder", branch = "polkadot-v1.2.0", default-features = false }
-
 # Local dependencies
 assets-registry = { path = "../../pallets/assets-registry", default-features = false }
 pallet-parachain-info = { path = "../../pallets/parachain-info", default-features = false }
@@ -157,7 +154,6 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"subbridge-pallets/runtime-benchmarks",
 	"pallet-uniques/runtime-benchmarks",
-	"orml-xcm-builder-kusama/runtime-benchmarks",
 ]
 std = [
 	"codec/std",
@@ -245,7 +241,6 @@ std = [
 	"sygma-percentage-feehandler/std",
 	"sygma-runtime-api/std",
 	"primitive-types/std",
-	"orml-xcm-builder-kusama/std",
 ]
 
 try-runtime = [


### PR DESCRIPTION
This PR adds the common XCM location converter HashedDescription, which is used across the ecosystem, to Khala and Rhala.

For reference, chains using HashedDescription include the [relay chain](https://github.com/polkadot-fellows/runtimes/blob/main/relay/kusama/src/xcm_config.rs#L76) and system parachains like the [Asset Hub](https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs#L93).

The PR also removes the deprecated TinkernetMultisig configs from Rhala.

- added HashedDescription account converter
- added WithComputedOrigin in XCM barrier