### PR TITLE
compute: switch migration account

### DIFF
--- a/runtime/khala/src/lib.rs
+++ b/runtime/khala/src/lib.rs
@@ -1845,7 +1845,7 @@ pub struct MigrationAccount;
 impl Get<AccountId32> for MigrationAccount {
     fn get() -> AccountId32 {
         let account: [u8; 32] =
-            hex_literal::hex!("9e6399cd577e8ac536bdc017675f747b2d1893ad9cc8c69fd17eef73d4e6e51e");
+            hex_literal::hex!("5492cf1c4c446223e1e26b29c5017a8cd4da21799cd7f497fab075b5567efd6f");
         account.into()
     }
 }

--- a/runtime/phala/src/lib.rs
+++ b/runtime/phala/src/lib.rs
@@ -1790,7 +1790,7 @@ pub struct MigrationAccount;
 impl Get<AccountId32> for MigrationAccount {
     fn get() -> AccountId32 {
         let account: [u8; 32] =
-            hex_literal::hex!("9e6399cd577e8ac536bdc017675f747b2d1893ad9cc8c69fd17eef73d4e6e51e");
+            hex_literal::hex!("5492cf1c4c446223e1e26b29c5017a8cd4da21799cd7f497fab075b5567efd6f");
         account.into()
     }
 }

--- a/runtime/rhala/src/lib.rs
+++ b/runtime/rhala/src/lib.rs
@@ -1837,7 +1837,7 @@ pub struct MigrationAccount;
 impl Get<AccountId32> for MigrationAccount {
     fn get() -> AccountId32 {
         let account: [u8; 32] =
-            hex_literal::hex!("9e6399cd577e8ac536bdc017675f747b2d1893ad9cc8c69fd17eef73d4e6e51e");
+            hex_literal::hex!("5492cf1c4c446223e1e26b29c5017a8cd4da21799cd7f497fab075b5567efd6f");
         account.into()
     }
 }

--- a/runtime/thala/src/lib.rs
+++ b/runtime/thala/src/lib.rs
@@ -1827,7 +1827,7 @@ pub struct MigrationAccount;
 impl Get<AccountId32> for MigrationAccount {
     fn get() -> AccountId32 {
         let account: [u8; 32] =
-            hex_literal::hex!("9e6399cd577e8ac536bdc017675f747b2d1893ad9cc8c69fd17eef73d4e6e51e");
+            hex_literal::hex!("5492cf1c4c446223e1e26b29c5017a8cd4da21799cd7f497fab075b5567efd6f");
         account.into()
     }
 }


### PR DESCRIPTION
This PR will switch the migration account used in the compute pallet to a new account controlled by the Phala team.